### PR TITLE
Fixed recompilation for termonad built through .nix-helpers/termonad-with-packages.nix

### DIFF
--- a/.nix-helpers/termonad-with-packages.nix
+++ b/.nix-helpers/termonad-with-packages.nix
@@ -1,0 +1,45 @@
+
+# This file takes some optional arguments and produces a wrapper around
+# termonad that will know where to find a GHC with the libraries needed to
+# recompile its config file. This is not NixOS only; it should work with nix
+# on any system.
+#
+# Example usage in an overlay:
+#
+# > # This file at ~/.config/nixpkgs/overlays/termonad-overlay.nix
+# > self: super:
+# > let packages = hp: [ hp.colour hp.lens hp.MonadRandom ]; in
+# > { termonad = super.callPackage
+# >     (import /path/to/termonad-with-packages.nix { inherit packages; }) {};
+# > }
+#
+# Then termonad can be installed through nix's standard methods, e.g. nix-env.
+# If it's to be installed on NixOS through configuration.nix, then the overlay
+# too will need to be explicitly declared there, e.g.
+# > nixpkgs.overlays = [ (import /path/to/termonad-overlay.nix) ];
+#
+# Note that packages has a default value; you don't need to define your own.
+# To use the default, just pass in {} rather than { inherit packages; }.
+
+let
+  nixpkgs  = import ./nixpkgs.nix;
+  termonad = nixpkgs.callPackage ../. {};
+  defghcWithP = nixpkgs.haskellPackages.ghcWithPackages;
+  defpackages = self: [ self.colour self.lens ];
+in
+
+{ ghcWithPackages ? defghcWithP, packages ? defpackages }:
+let env = ghcWithPackages (self: [ termonad ] ++ packages self); in
+
+{ stdenv, makeWrapper }:
+stdenv.mkDerivation {
+  name = "termonad-with-packages-${env.version}";
+  nativeBuildInputs = [ makeWrapper ];
+  buildCommand = ''
+    mkdir -p $out/bin
+    makeWrapper ${env}/bin/termonad $out/bin/termonad \
+      --set NIX_GHC "${env}/bin/ghc"
+  '';
+  preferLocalBuild = true;
+  allowSubstitutes = false;
+}


### PR DESCRIPTION
Recompilation is a bit of a mess atm; it didn't work at all on my system (not even using the `running-termonad.nix` file with nix-shell, though in retrospect I guess `--pure` would have done it) so I had a look into it.

It turns out that nix-patched dyre looks to the `$NIX_GHC` env var for a ghc, then looks in the `$PATH` if that's unset. Without a wrapper setting `$NIX_GHC` correctly for termonad, it will either find nothing there, or as it seems happened in my case, use the `$NIX_GHC` crafted for xmonad instead. So I took inspiration from the way xmonad is packaged and wrote a secondary derivation that wraps termonad to give it a correct `$NIX_GHC` without running in a nix-shell or polluting the system environment.

A comment in the file itself has a little more exposition.

I've left my changes isolated to this one new file. Changes left unmade include:
 - `README.md`: The scope of the fix isn't NixOS only, but I didn't want to edit every other OS's section to say "install it through nix if you want recompilation to work". I'll let you try it out and see what you want the readme to say.
 - The other .nix files might better be refactored so that building in the termonad directory uses the wrapped version.
 - `termonad.cabal`: extra-source-files.