### PR TITLE
Try removing the min-width style.

### DIFF
--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -121,7 +121,7 @@ setupScreenStyle = do
             -- , "  border-width: 200px;"
             , "  background-color: #aaaaaa;"
             -- , "  color: #ff0000;"
-            , "  min-width: 4px;"
+            -- , "  min-width: 4px;"
             , "}"
             -- , "scrollbar trough {"
             -- , "  -GtkRange-slider-width: 200px;"


### PR DESCRIPTION
This PR removes the use of the `min-width` style property, which appears to not be supported on older(?) versions of GTK.

@lehins, could you try compiling Termonad this PR and make sure it works for you?  If it does, I'll go ahead and merge it in.

Hopefully fixes #21.