### PR TITLE
Change fontsize to be a sumtype.

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,8 @@ module Main where
 import Data.Colour.SRGB (Colour, sRGB24)
 import Termonad.App (defaultMain)
 import Termonad.Config
-  ( FontConfig, ShowScrollbar(ShowScrollbarAlways), cursorColor
-  , defaultFontConfig, defaultTMConfig, fontConfig, fontFamily
+  ( FontConfig, FontSize(FontSizePoints), ShowScrollbar(ShowScrollbarAlways)
+  , cursorColor, defaultFontConfig, defaultTMConfig, fontConfig, fontFamily
   , fontSize, showScrollbar
   )
 
@@ -194,7 +194,7 @@ fontConf :: FontConfig
 fontConf =
   defaultFontConfig
     { fontFamily = "DejaVu Sans Mono"
-    , fontSize = 13
+    , fontSize = FontSizePoints 13
     }
 
 main :: IO ()

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -76,7 +76,8 @@ import GI.Vte
 
 import Paths_termonad (getDataFileName)
 import Termonad.Config
-  ( FontConfig(fontFamily, fontSize, fontInPixels)
+  ( FontConfig(fontFamily, fontSize)
+  , FontSize(FontSizePoints, FontSizeUnits)
   , TMConfig
   , lensFontConfig
   , lensConfirmExit
@@ -155,10 +156,11 @@ createFontDesc tmConfig = do
   fontDesc <- fontDescriptionNew
   let fontConf = tmConfig ^. lensFontConfig
   fontDescriptionSetFamily fontDesc (fontFamily fontConf)
-  let fSize = fromIntegral (fontSize fontConf) * SCALE
-  if fontInPixels fontConf
-    then fontDescriptionSetAbsoluteSize fontDesc (fromIntegral fSize)
-    else fontDescriptionSetSize fontDesc fSize
+  case fontSize fontConf of
+    FontSizePoints points ->
+      fontDescriptionSetSize fontDesc $ fromIntegral (points * fromIntegral SCALE)
+    FontSizeUnits units ->
+      fontDescriptionSetAbsoluteSize fontDesc $ units * fromIntegral SCALE
   pure fontDesc
 
 compareScrolledWinAndTab :: ScrolledWindow -> a -> TMNotebookTab -> Bool

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -4,31 +4,65 @@ module Termonad.Config where
 
 import Termonad.Prelude
 
-import Control.Lens (makeLensesFor)
+import Control.Lens (makeLensesFor, makePrisms)
 import Data.Colour (Colour)
 import Data.Colour.Names -- (grey)
 
+-- | The font size for the Termonad terminal.  There are two ways to set the
+-- fontsize, corresponding to the two different ways to set the font size in
+-- the Pango font rendering library.
+--
+-- If you're not sure which to use, try 'FontSizePoints' first and see how it
+-- looks.  It should generally correspond to font sizes you are used to from
+-- other applications.
+data FontSize
+  = FontSizePoints Int
+    -- ^ This sets the font size based on \"points\".  The conversion between a
+    -- point and an actual size depends on the system configuration and the
+    -- output device.  The function 'GI.Pango.fontDescriptionSetSize' is used
+    -- to set the font size.  See the documentation for that function for more
+    -- info.
+  | FontSizeUnits Double
+    -- ^ This sets the font size based on \"device units\".  In general, this
+    -- can be thought of as one pixel.  The function
+    -- 'GI.Pango.fontDescriptionSetAbsoluteSize' is used to set the font size.
+    -- See the documentation for that function for more info.
+  deriving (Eq, Show)
+
+-- | The default 'FontSize' used if not specified.
+--
+-- >>> defaultFontSize
+-- FontSizePoints 12
+defaultFontSize :: FontSize
+defaultFontSize = FontSizePoints 12
+
+$(makePrisms ''FontSize)
+
+-- | Settings for the font to be used in Termonad.
 data FontConfig = FontConfig
   { fontFamily :: !Text
-  , fontSize :: !Int
-  , fontInPixels :: !Bool
+    -- ^ The font family to use.  Example: @"DejaVu Sans Mono"@ or @"Source Code Pro"@
+  , fontSize :: !FontSize
+    -- ^ The font size.
   } deriving (Eq, Show)
+
+-- | The default 'FontConfig' to use if not specified.
+--
+-- >>> defaultFontConfig == FontConfig {fontFamily = "Monospace", fontSize = defaultFontSize}
+-- True
+defaultFontConfig :: FontConfig
+defaultFontConfig =
+  FontConfig
+    { fontFamily = "Monospace"
+    , fontSize = defaultFontSize
+    }
 
 $(makeLensesFor
     [ ("fontFamily", "lensFontFamily")
     , ("fontSize", "lensFontSize")
-    , ("fontInPixels", "lensFontInPixels")
     ]
     ''FontConfig
  )
-
-defaultFontConfig :: FontConfig
-defaultFontConfig =
-  FontConfig
-    { fontFamily = "Monospace" -- or "DejaVu Sans Mono" or "Bitstream Vera Sans Mono Roman" or "Source Code Pro"
-    , fontSize = 12
-    , fontInPixels = False
-    }
 
 data ShowScrollbar
   = ShowScrollbarNever


### PR DESCRIPTION
This changes the font size setting to be  a sumtype to better reflect the two options.

@LSLeary originally implemented the pixel-based font-size option.