### PR TITLE
Implemented basic colour configuration

### DIFF
--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -6,7 +6,7 @@ import Termonad.Prelude
 
 import Control.Lens (makeLensesFor, makePrisms)
 import Data.Colour (Colour)
-import Data.Colour.Names -- (grey)
+import Data.Colour.SRGB (sRGB24)
 
 -- | The font size for the Termonad terminal.  There are two ways to set the
 -- fontsize, corresponding to the two different ways to set the font size in
@@ -64,6 +64,47 @@ $(makeLensesFor
     ''FontConfig
  )
 
+data ColourConfig c = ColourConfig
+  { cursorColour :: !c
+  , foregroundColour :: !c
+  , backgroundColour :: !c
+  , palette :: ![c]
+  } deriving (Eq, Show, Functor)
+
+$(makeLensesFor
+    [ ("cursorColour", "lensCursorColour")
+    , ("foregroundColour", "lensForegroundColour")
+    , ("backgroundColour", "lensBackgroundColour")
+    , ("palette", "lensPalette")
+    ]
+    ''ColourConfig
+ )
+
+defaultColourConfig :: ColourConfig (Colour Double)
+defaultColourConfig = ColourConfig
+  { cursorColour = sRGB24 192 192 192 -- lightgrey
+  , foregroundColour = sRGB24 192 192 192 -- lightgrey
+  , backgroundColour = sRGB24   0   0   0 -- black
+  , palette =
+    [ sRGB24   0   0   0 -- 00: black
+    , sRGB24 192   0   0 -- 01: red
+    , sRGB24   0 192   0 -- 02: green
+    , sRGB24 192 192   0 -- 03: yellow
+    , sRGB24   0   0 192 -- 04: blue
+    , sRGB24 192   0 192 -- 05: purple
+    , sRGB24   0 192 192 -- 06: cyan
+    , sRGB24 192 192 192 -- 07: lightgrey
+    , sRGB24  63  63  63 -- 08: grey
+    , sRGB24 255  63  63 -- 09: lightred
+    , sRGB24  63 255  63 -- 10: lightgreen
+    , sRGB24 255 255  63 -- 11: lightyellow
+    , sRGB24  63  63 255 -- 12: lightblue
+    , sRGB24 255  63 255 -- 13: lightpurple
+    , sRGB24  63 255 255 -- 14: lightcyan
+    , sRGB24 255 255 255 -- 15: white
+    ]
+  }
+
 data ShowScrollbar
   = ShowScrollbarNever
   | ShowScrollbarAlways
@@ -73,7 +114,7 @@ data ShowScrollbar
 data TMConfig = TMConfig
   { fontConfig :: !FontConfig
   , showScrollbar :: !ShowScrollbar
-  , cursorColor :: !(Colour Double)
+  , colourConfig :: !(ColourConfig (Colour Double))
   , scrollbackLen :: !Integer
   , confirmExit :: !Bool
   , wordCharExceptions :: !Text
@@ -82,7 +123,7 @@ data TMConfig = TMConfig
 $(makeLensesFor
     [ ("fontConfig", "lensFontConfig")
     , ("showScrollbar", "lensShowScrollbar")
-    , ("cursorColor", "lensCursorColor")
+    , ("colourConfig", "lensColourConfig")
     , ("scrollbackLen", "lensScrollbackLen")
     , ("confirmExit", "lensConfirmExit")
     , ("wordCharExceptions", "lensWordCharExceptions")
@@ -95,7 +136,7 @@ defaultTMConfig =
   TMConfig
     { fontConfig = defaultFontConfig
     , showScrollbar = ShowScrollbarIfNeeded
-    , cursorColor = lightgrey
+    , colourConfig = defaultColourConfig
     , scrollbackLen = 10000
     , confirmExit = True
     , wordCharExceptions = "-#%&+,./=?@\\_~\183:"

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -5,7 +5,7 @@ module Termonad.Term where
 import Termonad.Prelude
 
 import Control.Lens ((^.), (&), (.~), set, to)
-import Data.Colour.SRGB (RGB(RGB), toSRGB)
+import Data.Colour.SRGB (Colour, RGB(RGB), toSRGB)
 import GI.Gdk
   ( EventKey
   , RGBA
@@ -74,6 +74,7 @@ import GI.Vte
   , terminalGetWindowTitle
   , terminalNew
   , terminalSetCursorBlinkMode
+  , terminalSetColors
   , terminalSetColorCursor
   , terminalSetFont
   , terminalSetScrollbackLines
@@ -85,7 +86,8 @@ import System.Directory (getSymbolicLinkTarget)
 
 import Termonad.Config
   ( ShowScrollbar(..)
-  , TMConfig(cursorColor, scrollbackLen, wordCharExceptions)
+  , TMConfig(scrollbackLen, wordCharExceptions, colourConfig)
+  , ColourConfig(..)
   , lensShowScrollbar
   , lensConfirmExit
   )
@@ -239,10 +241,9 @@ createNotebookTabLabel = do
   widgetShow button
   pure (box, label, button)
 
-getCursorColor :: TMConfig -> IO RGBA
-getCursorColor tmConfig = do
-  let color = cursorColor tmConfig
-      RGB red green blue = toSRGB color
+toRGBA :: Colour Double -> IO RGBA
+toRGBA colour = do
+  let RGB red green blue = toSRGB colour
   rgba <- newZeroRGBA
   setRGBARed rgba red
   setRGBAGreen rgba green
@@ -280,8 +281,13 @@ createTerm handleKeyPress mvarTMState = do
   terminalSetFont vteTerm (Just tmStateFontDesc)
   terminalSetWordCharExceptions vteTerm $ wordCharExceptions tmStateConfig
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen tmStateConfig))
-  cursorColor <- getCursorColor tmStateConfig
-  terminalSetColorCursor vteTerm (Just cursorColor)
+  let colourConf = colourConfig tmStateConfig
+      mGetRGBA accessor = Just <$> toRGBA (accessor colourConf)
+  terminalSetColorCursor vteTerm =<< mGetRGBA cursorColour
+  join $ terminalSetColors vteTerm
+    <$> mGetRGBA foregroundColour
+    <*> mGetRGBA backgroundColour
+    <*> (Just <$> traverse toRGBA (palette colourConf))
   terminalSetCursorBlinkMode vteTerm CursorBlinkModeOn
   widgetShow vteTerm
   widgetGrabFocus $ vteTerm

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -87,6 +87,7 @@ library
                      , TypeApplications
                      , TypeFamilies
                      , TypeOperators
+                     , DeriveFunctor
   other-extensions:    TemplateHaskell
   pkgconfig-depends:   gtk+-3.0
 


### PR DESCRIPTION
With one big problem ... I can't set the background colour? `terminalSetColors` is meant to do it but it doesn't. I tried doubling up and using `terminalSetColorBackground` too—didn't change anything. Am I doing something wrong or is it a bug in `gi-vte`?