### PR TITLE
Type-safe palette

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -22,6 +22,9 @@ let
     sha256 = "14cyj1acxs39avciyzqqb1qa5dr4my8rv3mfwv1kv92wa9a5i97v";
   };
 
+  overrideTC = lib: compiler == "ghcHEAD" ||
+    lib.strings.toInt (lib.strings.removePrefix "ghc" compiler) > 822;
+
   haskellPackagesOL = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${compiler}.override {
       overrides = hself: hsuper: {
@@ -46,6 +49,16 @@ let
             sha256 = "072d680j1k3n0vkzsbghhnah2p799yxrm7mhvr0nkdvr7iy04gcz";
           };
         });
+        type-combinators =
+          if ! overrideTC super.stdenv.lib then hsuper.type-combinators else
+          hsuper.type-combinators.overrideAttrs (oa: {
+            src = super.fetchFromGitHub {
+              owner = "kylcarte";
+              repo = "type-combinators";
+              rev = "071942730b6bb34990d37e1a25236382cf0dcbc6";
+              sha256 = "09criipy1ry2ala8bmr5np14cdr6ncph8zd0ald152jcrfh0fphm";
+            };
+          });
       };
     };
   };

--- a/.nix-helpers/termonad.nix
+++ b/.nix-helpers/termonad.nix
@@ -2,7 +2,7 @@
 , constraints, data-default, doctest, dyre, gi-gdk, gi-gio, gi-glib
 , gi-gtk, gi-pango, gi-vte, gtk3, haskell-gi-base, hedgehog, lens
 , pretty-simple, QuickCheck, stdenv, tasty, tasty-hedgehog
-, template-haskell, xml-conduit, xml-html-qq
+, template-haskell, type-combinators, xml-conduit, xml-html-qq
 }:
 mkDerivation {
   pname = "termonad";
@@ -19,7 +19,7 @@ mkDerivation {
   libraryHaskellDepends = [
     base classy-prelude colour constraints data-default dyre gi-gdk
     gi-gio gi-glib gi-gtk gi-pango gi-vte haskell-gi-base lens
-    pretty-simple QuickCheck xml-conduit xml-html-qq
+    pretty-simple QuickCheck type-combinators xml-conduit xml-html-qq
   ];
   libraryPkgconfigDepends = [ gtk3 ];
   executableHaskellDepends = [ base ];

--- a/src/Termonad.hs
+++ b/src/Termonad.hs
@@ -1,7 +1,10 @@
 module Termonad
   ( defaultMain
+  , pattern (:+)
   , module Config
   ) where
 
 import Termonad.App (defaultMain)
 import Termonad.Config as Config
+
+import Data.Type.Vector (pattern (:+))

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -76,6 +76,8 @@ import GI.Vte
   , terminalSetCursorBlinkMode
   , terminalSetColors
   , terminalSetColorCursor
+--, terminalSetColorBackground
+  , terminalSetColorForeground
   , terminalSetFont
   , terminalSetScrollbackLines
   , terminalSpawnSync
@@ -90,6 +92,7 @@ import Termonad.Config
   , ColourConfig(..)
   , lensShowScrollbar
   , lensConfirmExit
+  , paletteToList
   )
 import Termonad.FocusList (appendFL, deleteFL, getFLFocusItem)
 import Termonad.Types
@@ -284,12 +287,12 @@ createTerm handleKeyPress mvarTMState = do
   terminalSetWordCharExceptions vteTerm $ wordCharExceptions tmStateConfig
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen tmStateConfig))
   let colourConf = colourConfig tmStateConfig
-      mGetRGBA accessor = Just <$> toRGBA (accessor colourConf)
-  terminalSetColorCursor vteTerm =<< mGetRGBA cursorColour
-  join $ terminalSetColors vteTerm
-    <$> mGetRGBA foregroundColour
-    <*> mGetRGBA backgroundColour
-    <*> (Just <$> traverse toRGBA (palette colourConf))
+  terminalSetColors vteTerm Nothing Nothing . Just
+    =<< traverse toRGBA (paletteToList . palette $ colourConf)
+  -- PR#28/IS#29: Setting the background colour is broken in gi-vte or VTE.
+--terminalSetColorBackground vteTerm =<< toRGBA (backgroundColour colourConf)
+  terminalSetColorForeground vteTerm =<< toRGBA (foregroundColour colourConf)
+  terminalSetColorCursor vteTerm . Just =<< toRGBA (cursorColour colourConf)
   terminalSetCursorBlinkMode vteTerm CursorBlinkModeOn
   widgetShow vteTerm
   widgetGrabFocus $ vteTerm

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -64,15 +64,20 @@ library
                      , lens
                      , pretty-simple
                      , QuickCheck
+                     , type-combinators
                      , xml-conduit
                      , xml-html-qq
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds
+                     , FlexibleContexts
+                     , FlexibleInstances
                      , GADTs
                      , GeneralizedNewtypeDeriving
                      , InstanceSigs
                      , KindSignatures
+                     , LambdaCase
+                     , MultiParamTypeClasses
                      , NamedFieldPuns
                      , NoImplicitPrelude
                      , OverloadedStrings
@@ -87,7 +92,10 @@ library
                      , TypeFamilies
                      , TypeOperators
                      , DeriveFunctor
+                     , DeriveFoldable
+                     , StandaloneDeriving
   other-extensions:    TemplateHaskell
+                     , UndecidableInstances
   pkgconfig-depends:   gtk+-3.0
 
 executable termonad


### PR DESCRIPTION
> Type-safe palette representation:
>  * Example/default values for each palette entry.
>  * Function to generate colour cubes.
>  * Heaps of vector and matrix utilities.
>  * Organisation via text folding in Config.hs.

I got a bit carried away writing this one. type-combinators didn't have as many handy utility functions as I'd been expecting, though it did have enough supporting machinery to easily justify its use. It was also lacking a few instances we could do with. For now they're orphans derived/declared in `Termonad.Config`, but I've submitted PRs upstream; hopefully they're accepted and the orphans can be dropped as soon as there's a hackage version including the changes. The written utilities are also quite general, so they too hopefully will be accepted upstream and dropped here.

`Config.hs` was becoming pretty unruly, so to ease my own navigation of the file I introduced text folds with the commonly used markers `{{{` and `}}}`—it's something I do in all the modules I write. It also improves organisation by dividing the file into sections and subsections. But I can remove them if you prefer.

Edit: for posterity, discussion is in #28.