### PR TITLE
fix missing import.

### DIFF
--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -4,7 +4,7 @@ module Termonad.Term where
 
 import Termonad.Prelude
 
-import Control.Lens ((^.), (&), (.~), set, to)
+import Control.Lens ((^.), (&), (<&>), (.~), set, to)
 import Data.Colour.SRGB (Colour, RGB(RGB), toSRGB)
 import GI.Gdk
   ( EventKey


### PR DESCRIPTION
`(<&>)` was missing to be imported in `Termonad.Term`.