### PR TITLE
Patch gtk

### DIFF
--- a/.nix-helpers/patches/gdk.patch
+++ b/.nix-helpers/patches/gdk.patch
@@ -1,0 +1,16 @@
+diff --git a/gdk/quartz/gdkquartz.h b/gdk/quartz/gdkquartz.h
+index be2cb3c..24555d4 100644
+--- a/gdk/quartz/gdkquartz.h
++++ b/gdk/quartz/gdkquartz.h
+@@ -60,8 +60,11 @@ typedef enum
+ GDK_AVAILABLE_IN_ALL
+ GdkOSXVersion gdk_quartz_osx_version (void);
+ 
++GDK_AVAILABLE_IN_ALL
+ GdkAtom   gdk_quartz_pasteboard_type_to_atom_libgtk_only        (NSString       *type);
++GDK_AVAILABLE_IN_ALL
+ NSString *gdk_quartz_target_to_pasteboard_type_libgtk_only      (const gchar    *target);
++GDK_AVAILABLE_IN_ALL
+ NSString *gdk_quartz_atom_to_pasteboard_type_libgtk_only        (GdkAtom         atom);
+ 
+ G_END_DECLS

--- a/.nix-helpers/stack-nix-shell.nix
+++ b/.nix-helpers/stack-nix-shell.nix
@@ -15,7 +15,18 @@ let
     #url = "https://github.com/NixOS/nixpkgs/archive/4ccaa7de8eb34a0bb140f109a0e88095480118eb.tar.gz";
     #sha256 = "0szbxfrzmlmxrgkqz5wnfgmsjp82vaddgz7mhdz7jj0jhd0hza4i";
   };
-  nixpkgs = import nixpkgsTarball { };
+
+  pkgFixes = self: pkgs: {
+    gtk3 = pkgs.gtk3.overrideDerivation (oldattrs: {
+      patches = oldattrs.patches ++ [ ./patches/gdk.patch ];
+    } );
+  };
+
+  nixpkgs = import nixpkgsTarball {
+    overlays = [
+      pkgFixes
+    ];
+  };
 in
 
 with nixpkgs;

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -4,7 +4,7 @@ module Termonad.Term where
 
 import Termonad.Prelude
 
-import Control.Lens ((^.), (&), (.~), set, to)
+import Control.Lens ((^.), (&), (<&>), (.~), set, to)
 import Data.Colour.SRGB (Colour, RGB(RGB), toSRGB)
 import GI.Gdk
   ( EventKey


### PR DESCRIPTION
This fixes a runtime error on macOS.

The error was coming from the gtk nix package trying to call some quartz function which was not exposed properly.
I wrote a patch and updated nix configuration.

This goes on top of #41 .
Fix #40 .