### PR TITLE
Make sure to use the latest version of type-combinators in lts-12.

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -49,6 +49,7 @@ let
             sha256 = "072d680j1k3n0vkzsbghhnah2p799yxrm7mhvr0nkdvr7iy04gcz";
           };
         });
+        # This is for https://github.com/cdepillabout/termonad/pull/36.
         type-combinators =
           if ! overrideTC super.stdenv.lib then hsuper.type-combinators else
           hsuper.type-combinators.overrideAttrs (oa: {

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -11,6 +11,9 @@ packages:
 extra-deps:
     - gi-vte-2.91.19
     - gi-gtk-3.0.24
+    # This is for https://github.com/cdepillabout/termonad/pull/36.
+    - git: https://github.com/kylcarte/type-combinators.git
+      commit: 071942730b6bb34990d37e1a25236382cf0dcbc6
 
 # Override default flag values for local packages and extra-deps
 flags: {}


### PR DESCRIPTION
This PR adds the correct version of type-combinators to be used with
stack.  This if for #36.