### PR TITLE
Change the default palette from fullpalette to nopalette.

### DIFF
--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -186,8 +186,7 @@ defaultColourConfig = ColourConfig
   { cursorColour = sRGB24 192 192 192
   , foregroundColour = sRGB24 192 192 192
   , backgroundColour = sRGB24 0 0 0
-  , palette = FullPalette defaultStandardColours defaultLightColours
-                          defaultColourCube defaultGreyscale
+  , palette = NoPalette
   }
 
 -- }}}


### PR DESCRIPTION
This PR changes the default palette from FullPalette to NoPalette.

I think the colors from NoPalette look a little better than FullPalette.  Ideally, we could go through and pick out all the colors from VTE's entire color palette and set our FullPalette to be equal to them.  I think that would make it easiest for Termonad's users to start modifying their own color palettes, but it would take a lot of work figuring out exactly what colors VTE uses.  The code around setting default colors in VTE is somewhat complex:

https://gitlab.gnome.org/GNOME/vte/blob/db83de67084387a73031deaf984b21626879d6be/src/vte.cc#L2173

@LSLeary 