### PR TITLE
Cursor Foreground & The Option to Leave Unset

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ import Data.Colour.SRGB (Colour, sRGB24)
 import Termonad.App (defaultMain)
 import Termonad.Config
   ( FontConfig, FontSize(FontSizePoints), ShowScrollbar(ShowScrollbarAlways)
-  , cursorColor, defaultFontConfig, defaultTMConfig, fontConfig, fontFamily
+  , cursorBgColour, defaultFontConfig, defaultTMConfig, fontConfig, fontFamily
   , fontSize, showScrollbar
   )
 
@@ -259,7 +259,7 @@ main :: IO ()
 main = do
   let termonadConf =
         defaultTMConfig
-          { cursorColor = cursColor
+          { cursorBgColour = cursColor
           , fontConfig = fontConf
           -- Make sure the scrollbar is always visible.
           , showScrollbar = ShowScrollbarAlways

--- a/README.md
+++ b/README.md
@@ -236,8 +236,8 @@ import Data.Colour.SRGB (Colour, sRGB24)
 import Termonad.App (defaultMain)
 import Termonad.Config
   ( FontConfig, FontSize(FontSizePoints), ShowScrollbar(ShowScrollbarAlways)
-  , cursorBgColour, defaultFontConfig, defaultTMConfig, fontConfig, fontFamily
-  , fontSize, showScrollbar
+  , Option(Set), cursorBgColour, defaultFontConfig, defaultTMConfig, fontConfig
+  , fontFamily, fontSize, showScrollbar
   )
 
 -- | This sets the color of the cursor in the terminal.
@@ -259,7 +259,7 @@ main :: IO ()
 main = do
   let termonadConf =
         defaultTMConfig
-          { cursorBgColour = cursColor
+          { cursorBgColour = Set cursColor
           , fontConfig = fontConf
           -- Make sure the scrollbar is always visible.
           , showScrollbar = ShowScrollbarAlways

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -166,14 +166,16 @@ defaultGreyscale = vgen_ $ \n -> I $ blend (beta n) white black
 --   The @backgroundColour@ field will be ignored and the 0th colour in the
 --   palette (usually black) will be used as the background colour.
 data ColourConfig c = ColourConfig
-  { cursorColour :: !c
+  { cursorFgColour :: !c
+  , cursorBgColour :: !c
   , foregroundColour :: !c
   , backgroundColour :: !c
   , palette :: !(Palette c)
   } deriving (Eq, Show, Functor)
 
 $(makeLensesFor
-    [ ("cursorColour", "lensCursorColour")
+    [ ("cursorFgColour", "lensCursorFgColour")
+    , ("cursorBgColour", "lensCursorBgColour")
     , ("foregroundColour", "lensForegroundColour")
     , ("backgroundColour", "lensBackgroundColour")
     , ("palette", "lensPalette")
@@ -183,9 +185,10 @@ $(makeLensesFor
 
 defaultColourConfig :: (Ord b, Floating b) => ColourConfig (Colour b)
 defaultColourConfig = ColourConfig
-  { cursorColour = sRGB24 192 192 192
+  { cursorFgColour = black
+  , cursorBgColour = sRGB24 192 192 192
   , foregroundColour = sRGB24 192 192 192
-  , backgroundColour = sRGB24 0 0 0
+  , backgroundColour = black
   , palette = NoPalette
   }
 

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -161,13 +161,21 @@ defaultGreyscale :: (Ord b, Floating b) => Vec N24 (Colour b)
 defaultGreyscale = vgen_ $ \n -> I $ blend (beta n) white black
   where beta n = (fromIntegral (fin n) / 23) ** 2
 
+data Option a = Unset | Set !a
+  deriving (Show, Read, Eq, Ord, Functor, Foldable)
+
+whenSet :: Monoid m => Option a -> (a -> m) -> m
+whenSet = \case
+  Unset -> \_ -> mempty
+  Set x -> \f -> f x
+
 -- | NB: Currently due to issues either with VTE or the bindings generated for
 --   Haskell, background colour cannot be set independently of the palette.
 --   The @backgroundColour@ field will be ignored and the 0th colour in the
 --   palette (usually black) will be used as the background colour.
 data ColourConfig c = ColourConfig
-  { cursorFgColour :: !c
-  , cursorBgColour :: !c
+  { cursorFgColour :: !(Option c)
+  , cursorBgColour :: !(Option c)
   , foregroundColour :: !c
   , backgroundColour :: !c
   , palette :: !(Palette c)
@@ -185,8 +193,8 @@ $(makeLensesFor
 
 defaultColourConfig :: (Ord b, Floating b) => ColourConfig (Colour b)
 defaultColourConfig = ColourConfig
-  { cursorFgColour = black
-  , cursorBgColour = sRGB24 192 192 192
+  { cursorFgColour = Unset
+  , cursorBgColour = Unset
   , foregroundColour = sRGB24 192 192 192
   , backgroundColour = black
   , palette = NoPalette

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -101,6 +101,7 @@ import Termonad.Config
   , lensShowTabBar
   , lensConfirmExit
   , paletteToList
+  , whenSet
   )
 import Termonad.FocusList (appendFL, deleteFL, getFLFocusItem)
 import Termonad.Types
@@ -314,9 +315,10 @@ createTerm handleKeyPress mvarTMState = do
   -- PR#28/IS#29: Setting the background colour is broken in gi-vte or VTE.
 --terminalSetColorBackground vteTerm =<< toRGBA (backgroundColour colourConf)
   terminalSetColorForeground vteTerm =<< toRGBA (foregroundColour colourConf)
-  let perform setC cField = setC vteTerm . Just =<< toRGBA (cField colourConf)
-  perform terminalSetColorCursor cursorBgColour
-  perform terminalSetColorCursorForeground cursorFgColour
+  let optPerform setC cField = whenSet (cField colourConf) $ \c ->
+        setC vteTerm . Just =<< toRGBA c
+  optPerform terminalSetColorCursor cursorBgColour
+  optPerform terminalSetColorCursorForeground cursorFgColour
   terminalSetCursorBlinkMode vteTerm CursorBlinkModeOn
   widgetShow vteTerm
   -- Should probably use GI.Vte.Functions.getUserShell, but contrary to its

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -80,6 +80,7 @@ import GI.Vte
   , terminalSetCursorBlinkMode
   , terminalSetColors
   , terminalSetColorCursor
+  , terminalSetColorCursorForeground
 --, terminalSetColorBackground
   , terminalSetColorForeground
   , terminalSetFont
@@ -313,7 +314,9 @@ createTerm handleKeyPress mvarTMState = do
   -- PR#28/IS#29: Setting the background colour is broken in gi-vte or VTE.
 --terminalSetColorBackground vteTerm =<< toRGBA (backgroundColour colourConf)
   terminalSetColorForeground vteTerm =<< toRGBA (foregroundColour colourConf)
-  terminalSetColorCursor vteTerm . Just =<< toRGBA (cursorColour colourConf)
+  let perform setC cField = setC vteTerm . Just =<< toRGBA (cField colourConf)
+  perform terminalSetColorCursor cursorBgColour
+  perform terminalSetColorCursorForeground cursorFgColour
   terminalSetCursorBlinkMode vteTerm CursorBlinkModeOn
   widgetShow vteTerm
   -- Should probably use GI.Vte.Functions.getUserShell, but contrary to its


### PR DESCRIPTION
> `cdd0258`: Allow cursor foreground colour configuration.

With cursor background set, the cursor foreground defaults to the colour of the text underneath, which may be unreadable.

> `47b9a8e`: Add Option data type; hence allow cursor colours to remain unset.

For cursor colours, being unset is a special state not replicated by setting any one colour, so it should be amongst the configurable options. There probably will be (or already are) other config options for which this is the case, so rather than using `Maybe` as a one-off I've opted declare the (equivalent) data type `Option`.