### PR TITLE
Allow CursorBlinkMode configuration.

### DIFF
--- a/src/Termonad.hs
+++ b/src/Termonad.hs
@@ -1,6 +1,7 @@
 module Termonad
   ( defaultMain
   , pattern (:+)
+  , CursorBlinkMode(..)
   , module Config
   ) where
 
@@ -8,3 +9,4 @@ import Termonad.App (defaultMain)
 import Termonad.Config as Config
 
 import Data.Type.Vector (pattern (:+))
+import GI.Vte (CursorBlinkMode(..))

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -25,6 +25,7 @@ import Type.Family.Nat (N(..), N3, N6, N8, type (+))
 import Type.Family.List (Fsts3, Thds3)
 
 import qualified Data.Foldable
+import GI.Vte (CursorBlinkMode(CursorBlinkModeOn))
 
 -- }}}
 
@@ -380,6 +381,7 @@ data TMConfig = TMConfig
   , wordCharExceptions :: !Text
   , showMenu :: !Bool
   , showTabBar :: !ShowTabBar
+  , cursorBlinkMode :: !CursorBlinkMode
   } deriving (Eq, Show)
 
 $(makeLensesFor
@@ -391,6 +393,7 @@ $(makeLensesFor
     , ("wordCharExceptions", "lensWordCharExceptions")
     , ("showMenu", "lensShowMenu")
     , ("showTabBar", "lensShowTabBar")
+    , ("cursorBlinkMode", "lensCursorBlinkMode")
     ]
     ''TMConfig
  )
@@ -406,6 +409,7 @@ defaultTMConfig =
     , wordCharExceptions = "-#%&+,./=?@\\_~\183:"
     , showMenu = True
     , showTabBar = ShowTabBarIfNeeded
+    , cursorBlinkMode = CursorBlinkModeOn
     }
 
 -- }}}

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -70,8 +70,7 @@ import GI.Gtk
   )
 import GI.Pango (EllipsizeMode(EllipsizeModeMiddle))
 import GI.Vte
-  ( CursorBlinkMode(CursorBlinkModeOn)
-  , PtyFlags(PtyFlagsDefault)
+  ( PtyFlags(PtyFlagsDefault)
   , Terminal
   , onTerminalChildExited
   , onTerminalWindowTitleChanged
@@ -95,7 +94,7 @@ import System.Environment (lookupEnv)
 import Termonad.Config
   ( ShowScrollbar(..)
   , ShowTabBar(..)
-  , TMConfig(scrollbackLen, wordCharExceptions, colourConfig)
+  , TMConfig(scrollbackLen, wordCharExceptions, colourConfig, cursorBlinkMode)
   , ColourConfig(..)
   , lensShowScrollbar
   , lensShowTabBar
@@ -319,7 +318,7 @@ createTerm handleKeyPress mvarTMState = do
         setC vteTerm . Just =<< toRGBA c
   optPerform terminalSetColorCursor cursorBgColour
   optPerform terminalSetColorCursorForeground cursorFgColour
-  terminalSetCursorBlinkMode vteTerm CursorBlinkModeOn
+  terminalSetCursorBlinkMode vteTerm (cursorBlinkMode tmStateConfig)
   widgetShow vteTerm
   -- Should probably use GI.Vte.Functions.getUserShell, but contrary to its
   -- documentation it raises an exception rather wrap in Maybe.


### PR DESCRIPTION
I'm using the `CursorBlinkMode` type and constructors directly as configuration values, and reexporting them from the Termonad module.

I don't really know how VTE is going to treat `AnotherCursorBlinkMode x` values. I tried a few to see if it would crash, but it seems like it just ignores the setting. Maybe the constructor should be excluded from the reexport?