### PR TITLE
Remove type combinators

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -42,9 +42,6 @@ let
           ./..;
     });
 
-  overrideTC = lib: compiler == "ghcHEAD" ||
-    lib.strings.toInt (lib.strings.removePrefix "ghc" compiler) > 822;
-
   haskellPackagesOL = self: super: with super.haskell.lib; {
     haskellPackages = super.haskell.packages.${compiler}.override {
       overrides = hself: hsuper: {
@@ -64,17 +61,6 @@ let
             sha256 = "072d680j1k3n0vkzsbghhnah2p799yxrm7mhvr0nkdvr7iy04gcz";
           };
         });
-        # This is for https://github.com/cdepillabout/termonad/pull/36.
-        type-combinators =
-          if ! overrideTC super.stdenv.lib then hsuper.type-combinators else
-          hsuper.type-combinators.overrideAttrs (oa: {
-            src = super.fetchFromGitHub {
-              owner = "kylcarte";
-              repo = "type-combinators";
-              rev = "071942730b6bb34990d37e1a25236382cf0dcbc6";
-              sha256 = "09criipy1ry2ala8bmr5np14cdr6ncph8zd0ald152jcrfh0fphm";
-            };
-          });
       };
     };
   };

--- a/.nix-helpers/termonad.nix
+++ b/.nix-helpers/termonad.nix
@@ -1,9 +1,10 @@
-{ mkDerivation, base, Cabal, cabal-doctest, classy-prelude, colour
-, constraints, data-default, directory, doctest, dyre, filepath
-, genvalidity-hspec, gi-gdk, gi-gio, gi-glib, gi-gtk, gi-pango
-, gi-vte, gtk3, haskell-gi-base, hedgehog, lens, pretty-simple
-, QuickCheck, stdenv, tasty, tasty-hedgehog, tasty-hspec
-, template-haskell, type-combinators, xml-conduit, xml-html-qq
+{ mkDerivation, adjunctions, base, Cabal, cabal-doctest
+, classy-prelude, colour, constraints, data-default, directory
+, distributive, doctest, dyre, filepath, genvalidity-hspec, gi-gdk
+, gi-gio, gi-glib, gi-gtk, gi-pango, gi-vte, gtk3, haskell-gi-base
+, hedgehog, lens, pretty-simple, QuickCheck, singletons, stdenv
+, tasty, tasty-hedgehog, tasty-hspec, template-haskell, xml-conduit
+, xml-html-qq
 }:
 mkDerivation {
   pname = "termonad";
@@ -14,10 +15,10 @@ mkDerivation {
   enableSeparateDataOutput = true;
   setupHaskellDepends = [ base Cabal cabal-doctest ];
   libraryHaskellDepends = [
-    base classy-prelude colour constraints data-default directory dyre
-    filepath gi-gdk gi-gio gi-glib gi-gtk gi-pango gi-vte
-    haskell-gi-base lens pretty-simple QuickCheck type-combinators
-    xml-conduit xml-html-qq
+    adjunctions base classy-prelude colour constraints data-default
+    directory distributive dyre filepath gi-gdk gi-gio gi-glib gi-gtk
+    gi-pango gi-vte haskell-gi-base lens pretty-simple QuickCheck
+    singletons xml-conduit xml-html-qq
   ];
   libraryPkgconfigDepends = [ gtk3 ];
   executableHaskellDepends = [ base ];

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -181,11 +181,18 @@ showColourVec = fmap sRGB24show . Data.Foldable.toList
 -- | Specify a colour cube with one colour vector for its displacement and three
 -- colour vectors for its edges. Produces a uniform 6x6x6 grid bounded by
 -- and orthognal to the faces.
--- cube
---   :: Fractional b => Colour b -> Vec N3 (Colour b) -> Matrix '[N6, N6, N6] (Colour b)
--- cube d (i :* j :* k :* EmptyVec) = mgen_ $ \(x :< y :< z :< EmptyProd) ->
---   affineCombo [(1, d), (coef x, i), (coef y, j), (coef z, k)] black
---   where coef n = fromIntegral (fin n) / 5
+cube ::
+     forall b. Fractional b
+  => Colour b
+  -> Vec N3 (Colour b)
+  -> Matrix '[ N6, N6, N6] (Colour b)
+cube d (i :* j :* k :* EmptyVec) =
+  mgen_ $
+    \(x :< y :< z :< EmptyHList) ->
+      affineCombo [(1, d), (coef x, i), (coef y, j), (coef z, k)] black
+  where
+    coef :: Fin N6 -> b
+    coef fin = fromIntegral (toIntFin fin) / 5
 
 -- | A matrix of a 6 x 6 x 6 color cube. Default value for 'ColourCubePalette'.
 --

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -155,7 +155,7 @@ coloursFromBits scale offset = vgen_ createElem
       in color
 
     cmp :: Int -> Fin N8 -> Word8
-    cmp i = (offset +) . (scale *) . fromIntegral . bit i . fin
+    cmp i = (offset +) . (scale *) . fromIntegral . bit i . finToInt
 
     bit :: Int -> Int -> Int
     bit m i = i `div` (2 ^ m) `mod` 2
@@ -238,7 +238,7 @@ defaultColourCube = mgen_ $ \(x :< y :< z :< EmptyHList) -> sRGB24 (cmp x) (cmp 
   where
     cmp :: Fin N6 -> Word8
     cmp i =
-      let i' = fromIntegral (fin i)
+      let i' = fromIntegral (finToInt i)
       in signum i' * 55 + 40 * i'
 
 -- | Helper function for showing all the colors in a color cube. This is used
@@ -306,7 +306,7 @@ showColourCube matrix =
 -- ["#080808","#121212","#1c1c1c","#262626","#303030","#3a3a3a","#444444","#4e4e4e","#585858","#626262","#6c6c6c","#767676","#808080","#8a8a8a","#949494","#9e9e9e","#a8a8a8","#b2b2b2","#bcbcbc","#c6c6c6","#d0d0d0","#dadada","#e4e4e4","#eeeeee"]
 defaultGreyscale :: (Ord b, Floating b) => Vec N24 (Colour b)
 defaultGreyscale = vgen_ $ \n ->
-  let l = 8 + 10 * fromIntegral (fin n)
+  let l = 8 + 10 * fromIntegral (finToInt n)
   in sRGB24 l l l
 
 -- | The configuration for the colors used by Termonad.

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -144,7 +144,7 @@ paletteToList = Data.Foldable.toList
 --
 -- In general, as an end-user, you shouldn't need to use this.
 coloursFromBits :: forall b. (Ord b, Floating b) => Word8 -> Word8 -> Vec N8 (Colour b)
-coloursFromBits scale offset = vgen_ createElem
+coloursFromBits scale offset = genVec_ createElem
   where
     createElem :: Fin N8 -> Colour b
     createElem finN =
@@ -305,7 +305,7 @@ showColourCube matrix =
 -- >>> showColourVec defaultGreyscale
 -- ["#080808","#121212","#1c1c1c","#262626","#303030","#3a3a3a","#444444","#4e4e4e","#585858","#626262","#6c6c6c","#767676","#808080","#8a8a8a","#949494","#9e9e9e","#a8a8a8","#b2b2b2","#bcbcbc","#c6c6c6","#d0d0d0","#dadada","#e4e4e4","#eeeeee"]
 defaultGreyscale :: (Ord b, Floating b) => Vec N24 (Colour b)
-defaultGreyscale = vgen_ $ \n ->
+defaultGreyscale = genVec_ $ \n ->
   let l = 8 + 10 * fromIntegral (finToInt n)
   in sRGB24 l l l
 

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -187,7 +187,7 @@ cube ::
   -> Vec N3 (Colour b)
   -> Matrix '[ N6, N6, N6] (Colour b)
 cube d (i :* j :* k :* EmptyVec) =
-  mgen_ $
+  genMatrix_ $
     \(x :< y :< z :< EmptyHList) ->
       affineCombo [(1, d), (coef x, i), (coef y, j), (coef z, k)] black
   where
@@ -241,7 +241,8 @@ cube d (i :* j :* k :* EmptyVec) =
 --   ]
 -- ]
 defaultColourCube :: (Ord b, Floating b) => Matrix '[N6, N6, N6] (Colour b)
-defaultColourCube = mgen_ $ \(x :< y :< z :< EmptyHList) -> sRGB24 (cmp x) (cmp y) (cmp z)
+defaultColourCube =
+  genMatrix_ $ \(x :< y :< z :< EmptyHList) -> sRGB24 (cmp x) (cmp y) (cmp z)
   where
     cmp :: Fin N6 -> Word8
     cmp i =

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -155,7 +155,7 @@ coloursFromBits scale offset = genVec_ createElem
       in color
 
     cmp :: Int -> Fin N8 -> Word8
-    cmp i = (offset +) . (scale *) . fromIntegral . bit i . finToInt
+    cmp i = (offset +) . (scale *) . fromIntegral . bit i . toIntFin
 
     bit :: Int -> Int -> Int
     bit m i = i `div` (2 ^ m) `mod` 2
@@ -238,7 +238,7 @@ defaultColourCube = mgen_ $ \(x :< y :< z :< EmptyHList) -> sRGB24 (cmp x) (cmp 
   where
     cmp :: Fin N6 -> Word8
     cmp i =
-      let i' = fromIntegral (finToInt i)
+      let i' = fromIntegral (toIntFin i)
       in signum i' * 55 + 40 * i'
 
 -- | Helper function for showing all the colors in a color cube. This is used
@@ -306,7 +306,7 @@ showColourCube matrix =
 -- ["#080808","#121212","#1c1c1c","#262626","#303030","#3a3a3a","#444444","#4e4e4e","#585858","#626262","#6c6c6c","#767676","#808080","#8a8a8a","#949494","#9e9e9e","#a8a8a8","#b2b2b2","#bcbcbc","#c6c6c6","#d0d0d0","#dadada","#e4e4e4","#eeeeee"]
 defaultGreyscale :: (Ord b, Floating b) => Vec N24 (Colour b)
 defaultGreyscale = genVec_ $ \n ->
-  let l = 8 + 10 * fromIntegral (finToInt n)
+  let l = 8 + 10 * fromIntegral (toIntFin n)
   in sRGB24 l l l
 
 -- | The configuration for the colors used by Termonad.

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -234,7 +234,7 @@ showColourVec = fmap sRGB24show . Data.Foldable.toList
 --   ]
 -- ]
 defaultColourCube :: (Ord b, Floating b) => Matrix '[N6, N6, N6] (Colour b)
-defaultColourCube = mgen_ $ \(x :< y :< z :< EmptyProd) -> sRGB24 (cmp x) (cmp y) (cmp z)
+defaultColourCube = mgen_ $ \(x :< y :< z :< EmptyHList) -> sRGB24 (cmp x) (cmp y) (cmp z)
   where
     cmp :: Fin N6 -> Word8
     cmp i =
@@ -305,7 +305,7 @@ showColourCube matrix =
 -- >>> showColourVec defaultGreyscale
 -- ["#080808","#121212","#1c1c1c","#262626","#303030","#3a3a3a","#444444","#4e4e4e","#585858","#626262","#6c6c6c","#767676","#808080","#8a8a8a","#949494","#9e9e9e","#a8a8a8","#b2b2b2","#bcbcbc","#c6c6c6","#d0d0d0","#dadada","#e4e4e4","#eeeeee"]
 defaultGreyscale :: (Ord b, Floating b) => Vec N24 (Colour b)
-defaultGreyscale = vgen_ $ \n -> I $
+defaultGreyscale = vgen_ $ \n ->
   let l = 8 + 10 * fromIntegral (fin n)
   in sRGB24 l l l
 

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -58,7 +58,7 @@ import Text.Show (showParen, showString)
 
 -- updateSubmatrix
 --   :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
---   => Prod (Uncur3 Range) nlms -> (Prod Fin ms -> a -> a) -> M ns a -> M ns a
+--   => HList (Uncur3 Range) nlms -> (HList Fin ms -> a -> a) -> M ns a -> M ns a
 -- updateSubmatrix = \case
 --   Ø              -> \f -> (f Ø <$>)
 --   Uncur3 r :< rs -> \f -> onMatrix . updateRange r $ \i ->
@@ -66,7 +66,7 @@ import Text.Show (showParen, showString)
 
 -- setSubmatrix
 --   :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
---   => Prod (Uncur3 Range) nlms -> M ms a -> M ns a -> M ns a
+--   => HList (Uncur3 Range) nlms -> M ms a -> M ns a -> M ns a
 -- setSubmatrix rs sm = updateSubmatrix rs $ \is _ -> mIndex is sm
 
 
@@ -162,9 +162,9 @@ deriving instance Eq (Fin n)
 deriving instance Ord (Fin n)
 deriving instance Show (Fin n)
 
-finToInt :: Fin n -> Int
-finToInt FZ = 0
-finToInt (FS x) = succ $ finToInt x
+toIntFin :: Fin n -> Int
+toIntFin FZ = 0
+toIntFin (FS x) = succ $ toIntFin x
 
 data instance Sing (z :: Fin n) where
   SFZ :: Sing 'FZ
@@ -208,12 +208,12 @@ deriving instance Eq   (IFin x y)
 deriving instance Ord  (IFin x y)
 deriving instance Show (IFin x y)
 
-ifinToFin :: IFin n m -> Fin n
-ifinToFin IFZ = FZ
-ifinToFin (IFS n) = FS (ifinToFin n)
+toFinIFin :: IFin n m -> Fin n
+toFinIFin IFZ = FZ
+toFinIFin (IFS n) = FS (toFinIFin n)
 
-ifinToInt :: IFin n m -> Int
-ifinToInt = finToInt . ifinToFin
+toIntIFin :: IFin n m -> Int
+toIntIFin = toIntFin . toFinIFin
 
 data instance Sing (z :: IFin n m) where
   SIFZ :: Sing 'IFZ
@@ -244,22 +244,6 @@ instance Show (Sing n) => Show (Sing ('IFS n)) where
   showsPrec d (SIFS n) =
     showParen (d > 10) $
     showString "SIFS " . showsPrec 11 n
-
-----------
--- Prod --
-----------
-
-data Prod :: [Type] -> Type where
-  EmptyProd :: Prod '[]
-  ProdCons :: forall (a :: Type) (as :: [Type]). !a -> !(Prod as) -> Prod (a ': as)
-
--- | Infix operator for 'ProdCons.
-pattern (:<<) :: (a :: Type) -> Prod as -> Prod (a ': as)
-pattern a :<< prod = ProdCons a prod
-infixr 6 :<<
-
-curry' :: l ~ (a ': as) => (Prod l -> r) -> a -> Prod as -> r
-curry' f a as = f $ ProdCons a as
 
 -----------
 -- HList --

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -531,49 +531,42 @@ mindex EmptyHList (Matrix a) = a
 mindex (HListCons i is) (Matrix vec) = mindex is $ Matrix (vindex i vec)
 
 mmap :: forall (ns :: [Peano]) a b. Sing ns -> (HList Fin ns -> a -> b) -> Matrix ns a -> Matrix ns b
--- mmap ns f = go ns
 mmap SNil f (Matrix a) = Matrix (f EmptyHList a)
-mmap (SCons _ _) _ (Matrix EmptyVec) = error "in mmap, there is no way to reach this case, but GHC complains about it"
-mmap (SCons (n :: Sing (fefe :: Peano)) (ns :: Sing n2)) f (Matrix (VecCons (a :: MatrixTF n2 a) (as :: Vec m (MatrixTF n2 a)))) = Matrix (VecCons gogogo popopo)
-  where
-    gogogo :: MatrixTF n2 b
-    gogogo = unMatrix $ mmap ns ifif (Matrix a)
+mmap (SCons _ ns) f (Matrix vec) =
+  Matrix
+    (imap
+      (\fin -> unMatrix . mmap ns (\hlist -> f (HListCons fin hlist)) . Matrix)
+      vec
+    )
 
-    ifif :: HList Fin n2 -> a -> b
-    ifif hlist = f (oioio hlist)
-
-    oioio :: HList Fin n2 -> HList Fin ns
-    oioio hlist = HListCons gagaga hlist
-
-    gagaga :: Fin fefe
-    -- TODO: I don't think this is right
-    gagaga = FZ
-
-    popopo :: Vec m (MatrixTF n2 b)
-    popopo =
-      case n of
-        (SS (m :: Sing feo)) -> imap (oioi m) as
-
-    oioi :: forall (feo :: Peano). 'S feo ~ fefe => Sing feo -> Fin feo -> MatrixTF n2 a -> MatrixTF n2 b
-    oioi _ fin = unMatrix . apple . Matrix
-      where
-        apple :: Matrix n2 a -> Matrix n2 b
-        apple = mmap ns boohoo
-
-        boohoo :: HList Fin n2 -> a -> b
-        boohoo hlist = f (who hlist)
-
-        who :: HList Fin n2 -> HList Fin ns
-        who = HListCons (FS fin)
 
 mmap_ :: SingI ns => (HList Fin ns -> a -> b) -> Matrix ns a -> Matrix ns b
 mmap_ = mmap sing
 
-testtest :: Matrix '[N2, N3] String
-testtest = mmap_ f (Matrix ((1 :* 2 :* 3 :* EmptyVec) :* (4 :* 5 :* 6 :* EmptyVec) :* EmptyVec))
+testtest1 :: Matrix '[N2, N3] String
+testtest1 = mmap_ f (Matrix ((1 :* 2 :* 3 :* EmptyVec) :* (4 :* 5 :* 6 :* EmptyVec) :* EmptyVec))
   where
     f :: HList Fin '[N2, N3] -> Int -> String
     f (HListCons finA (HListCons finB EmptyHList)) i = show (i, finToInt finA, finToInt finB)
+
+testtest2 :: Matrix '[N2] String
+testtest2 = mmap_ f (Matrix (1 :* 2 :* EmptyVec))
+  where
+    f :: HList Fin '[N2] -> Int -> String
+    f (HListCons finA EmptyHList) i = show (i, finToInt finA)
+
+testtest3 :: Matrix '[] String
+testtest3 = mmap_ f (Matrix 100)
+  where
+    f :: HList Fin '[] -> Int -> String
+    f EmptyHList i = show i
+
+testtest4 :: Matrix '[N0, N2] String
+testtest4 = mmap_ f (Matrix EmptyVec)
+  where
+    f :: HList Fin '[N0, N2] -> Int -> String
+    f (HListCons (finA :: Fin N0) (HListCons (_ :: Fin N2) EmptyHList)) _ =
+      case finA of {}
 
 ----------------------
 -- Matrix Instances --

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -27,48 +27,12 @@ import Termonad.Prelude hiding ((\\), index)
 
 import Data.Distributive (Distributive(distribute))
 import qualified Data.Foldable as Data.Foldable
-import Data.Functor.Rep (Representable(..), distributeRep)
+import Data.Functor.Rep (Representable(..), apRep, bindRep, distributeRep, pureRep)
 import Data.Kind (Type)
 import Data.Singletons.Prelude
 import Data.Singletons.TH
 import Text.Show (showParen, showString)
 import Unsafe.Coerce (unsafeCoerce)
-
--- import Data.Type.Combinator (I(..), Uncur3(..))
--- import Data.Type.Fin (Fin(..), fin)
--- import Data.Type.Fin.Indexed (IFin(..))
--- import Data.Type.Length (Length)
--- import Data.Type.Nat (Nat(..))
--- import Data.Type.Product (Prod(..))
--- import Data.Type.Vector
---   ( M(M, getMatrix)
---   , Matrix
---   , Vec
---   , VecT(..)
---   , pattern (:+)
---   , index
---   , mgen_
---   , onMatrix
---   , onTail
---   , ppMatrix'
---   , tail'
---   , vgen_
---   )
--- import Type.Class.Known (Known(KnownC, known))
--- import Type.Class.Witness ((\\))
--- import Type.Family.List (Fsts3, Thds3)
--- import Type.Family.Nat (N(..), N3, N6, N8, type (+))
-
-----------------------
--- Orphan Instances --
-----------------------
-
--- instance Applicative (Matrix ns) => Applicative (M ns) where
---   pure = M . pure
---   M f <*> M a = M $ f <*> a
-
--- instance Monad (Matrix ns) => Monad (M ns) where
---   M ma >>= f = M (ma >>= getMatrix . f)
 
 --------------------------
 -- Misc VecT Operations --
@@ -353,6 +317,10 @@ instance SingI n => Representable (Vec n) where
 
   index :: Vec n a -> Fin n -> a
   index = flip vindex
+
+instance SingI n => Monad (Vec n) where
+  (>>=) :: Vec n a -> (a -> Vec n b) -> Vec n b
+  (>>=) = bindRep
 
 type instance Element (Vec n a) = a
 
@@ -653,3 +621,14 @@ instance Num a => Num (Matrix '[] a) where
 
   fromInteger :: Integer -> Matrix '[] a
   fromInteger = Matrix . fromInteger
+
+instance SingI ns => Applicative (Matrix ns) where
+  pure :: a -> Matrix ns a
+  pure = pureRep
+
+  (<*>) :: Matrix ns (a -> b) -> Matrix ns a -> Matrix ns b
+  (<*>) = apRep
+
+instance SingI ns => Monad (Matrix ns) where
+  (>>=) :: Matrix ns a -> (a -> Matrix ns b) -> Matrix ns b
+  (>>=) = bindRep

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -1,51 +1,60 @@
+{-# LANGUAGE TemplateHaskell #-}
+{-# LANGUAGE TypeInType #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# OPTIONS_GHC -Wno-orphans -Wno-unused-top-binds -Wno-unused-imports #-}
 
 module Termonad.Config.Vec
-  ( Fin
-  , I(I)
-  , M(M)
-  , N3
-  , N24
-  , N6
-  , N8
-  , Prod((:<), Ø)
-  , Range
-  , Vec
-  , VecT((:+), (:*), ØV, EmptyV)
-  , fin
-  , mgen_
-  , setSubmatrix
-  , vgen_
-  , vSetAt'
-  ) where
+  -- ( Fin
+  -- , I(I)
+  -- , M(M)
+  -- , N3
+  -- , N24
+  -- , N6
+  -- , N8
+  -- , Prod((:<), Ø)
+  -- , Range
+  -- , Vec
+  -- , VecT((:+), (:*), ØV, EmptyV)
+  -- , fin
+  -- , mgen_
+  -- , setSubmatrix
+  -- , vgen_
+  -- , vSetAt'
+  -- )
+    where
 
 import Termonad.Prelude hiding ((\\), index)
 
-import Data.Type.Combinator (I(..), Uncur3(..))
-import Data.Type.Fin (Fin(..), fin)
-import Data.Type.Fin.Indexed (IFin(..))
-import Data.Type.Length (Length)
-import Data.Type.Nat (Nat(..))
-import Data.Type.Product (Prod(..))
-import Data.Type.Vector
-  ( M(M, getMatrix)
-  , Matrix
-  , Vec
-  , VecT(..)
-  , pattern (:+)
-  , index
-  , mgen_
-  , onMatrix
-  , onTail
-  , ppMatrix'
-  , tail'
-  , vgen_
-  )
-import Type.Class.Known (Known(KnownC, known))
-import Type.Class.Witness ((\\))
-import Type.Family.List (Fsts3, Thds3)
-import Type.Family.Nat (N(..), N3, N6, N8, type (+))
+import Data.Kind (Type)
+import Data.Singletons.Prelude
+import Data.Singletons.Prelude.Num
+import Data.Singletons.Prelude.Show
+import Data.Singletons.TypeLits
+import Data.Singletons.TH
+
+-- import Data.Type.Combinator (I(..), Uncur3(..))
+-- import Data.Type.Fin (Fin(..), fin)
+-- import Data.Type.Fin.Indexed (IFin(..))
+-- import Data.Type.Length (Length)
+-- import Data.Type.Nat (Nat(..))
+-- import Data.Type.Product (Prod(..))
+-- import Data.Type.Vector
+--   ( M(M, getMatrix)
+--   , Matrix
+--   , Vec
+--   , VecT(..)
+--   , pattern (:+)
+--   , index
+--   , mgen_
+--   , onMatrix
+--   , onTail
+--   , ppMatrix'
+--   , tail'
+--   , vgen_
+--   )
+-- import Type.Class.Known (Known(KnownC, known))
+-- import Type.Class.Witness ((\\))
+-- import Type.Family.List (Fsts3, Thds3)
+-- import Type.Family.Nat (N(..), N3, N6, N8, type (+))
 
 ----------------------
 -- Orphan Instances --
@@ -54,31 +63,31 @@ import Type.Family.Nat (N(..), N3, N6, N8, type (+))
 -- These should eventually be provided by type-combinators.
 -- See https://github.com/kylcarte/type-combinators/pull/11.
 
-deriving instance Functor  (Matrix ns) => Functor  (M ns)
-deriving instance Foldable (Matrix ns) => Foldable (M ns)
+-- deriving instance Functor  (Matrix ns) => Functor  (M ns)
+-- deriving instance Foldable (Matrix ns) => Foldable (M ns)
 
-instance Applicative (Matrix ns) => Applicative (M ns) where
-  pure = M . pure
-  M f <*> M a = M $ f <*> a
+-- instance Applicative (Matrix ns) => Applicative (M ns) where
+--   pure = M . pure
+--   M f <*> M a = M $ f <*> a
 
-instance Monad (Matrix ns) => Monad (M ns) where
-  M ma >>= f = M (ma >>= getMatrix . f)
+-- instance Monad (Matrix ns) => Monad (M ns) where
+--   M ma >>= f = M (ma >>= getMatrix . f)
 
-instance Known (IFin ('S n)) 'Z where
-  known = IFZ
+-- instance Known (IFin ('S n)) 'Z where
+--   known = IFZ
 
-instance Known (IFin n) m => Known (IFin ('S n)) ('S m) where
-  type KnownC (IFin ('S n)) ('S m) = Known (IFin n) m
-  known = IFS known
+-- instance Known (IFin n) m => Known (IFin ('S n)) ('S m) where
+--   type KnownC (IFin ('S n)) ('S m) = Known (IFin n) m
+--   known = IFS known
 
 ---------------------------------
 -- Vector Helpers for Termonad --
 ---------------------------------
 
-type N24 = N8 + N8 + N8
+-- type N24 = N8 + N8 + N8
 
-pattern EmptyV :: VecT 'Z f c
-pattern EmptyV = ØV
+-- pattern EmptyV :: VecT 'Z f c
+-- pattern EmptyV = ØV
 
 --------------------------
 -- Misc VecT Operations --
@@ -87,79 +96,154 @@ pattern EmptyV = ØV
 -- These are waiting to be upstreamed at
 -- https://github.com/kylcarte/type-combinators/pull/11.
 
-onHead :: (f a -> f a) -> VecT ('S n) f a -> VecT ('S n) f a
-onHead f (a :* as) = f a :* as
+-- onHead :: (f a -> f a) -> VecT ('S n) f a -> VecT ('S n) f a
+-- onHead f (a :* as) = f a :* as
 
-take' :: IFin ('S n) m -> VecT n f a -> VecT m f a
-take' = \case
-  IFS n -> onTail (take' n) \\ n
-  IFZ   -> const EmptyV
+-- take' :: IFin ('S n) m -> VecT n f a -> VecT m f a
+-- take' = \case
+--   IFS n -> onTail (take' n) \\ n
+--   IFZ   -> const EmptyV
 
-drop' :: Nat m -> VecT (m + n) f a -> VecT n f a
-drop' = \case
-  S_ n -> drop' n . tail'
-  Z_   -> id
+-- drop' :: Nat m -> VecT (m + n) f a -> VecT n f a
+-- drop' = \case
+--   S_ n -> drop' n . tail'
+--   Z_   -> id
 
-asM :: (M ms a -> M ns a) -> (Matrix ms a -> Matrix ns a)
-asM f = getMatrix . f . M
+-- asM :: (M ms a -> M ns a) -> (Matrix ms a -> Matrix ns a)
+-- asM f = getMatrix . f . M
 
-mIndex :: Prod Fin ns -> M ns a -> a
-mIndex = \case
-  i :< is -> mIndex is . onMatrix (index i)
-  Ø       -> getI . getMatrix
+-- mIndex :: Prod Fin ns -> M ns a -> a
+-- mIndex = \case
+--   i :< is -> mIndex is . onMatrix (index i)
+--   Ø       -> getI . getMatrix
 
-deIndex :: IFin n m -> Fin n
-deIndex = \case
-  IFS n -> FS (deIndex n)
-  IFZ   -> FZ
+-- deIndex :: IFin n m -> Fin n
+-- deIndex = \case
+--   IFS n -> FS (deIndex n)
+--   IFZ   -> FZ
 
-vUpdateAt :: Fin n -> (f a -> f a) -> VecT n f a -> VecT n f a
-vUpdateAt = \case
-  FS m -> onTail . vUpdateAt m
-  FZ   -> onHead
+-- vUpdateAt :: Fin n -> (f a -> f a) -> VecT n f a -> VecT n f a
+-- vUpdateAt = \case
+--   FS m -> onTail . vUpdateAt m
+--   FZ   -> onHead
 
-vSetAt :: Fin n -> f a -> VecT n f a -> VecT n f a
-vSetAt n = vUpdateAt n . const
+-- vSetAt :: Fin n -> f a -> VecT n f a -> VecT n f a
+-- vSetAt n = vUpdateAt n . const
 
-vSetAt' :: Fin n -> a -> Vec n a -> Vec n a
-vSetAt' n = vSetAt n . I
+-- vSetAt' :: Fin n -> a -> Vec n a -> Vec n a
+-- vSetAt' n = vSetAt n . I
 
-mUpdateAt :: Prod Fin ns -> (a -> a) -> M ns a -> M ns a
-mUpdateAt = \case
-  n :< ns -> onMatrix . vUpdateAt n . asM . mUpdateAt ns
-  Ø       -> (<$>)
+-- mUpdateAt :: Prod Fin ns -> (a -> a) -> M ns a -> M ns a
+-- mUpdateAt = \case
+--   n :< ns -> onMatrix . vUpdateAt n . asM . mUpdateAt ns
+--   Ø       -> (<$>)
 
-mSetAt :: Prod Fin ns -> a -> M ns a -> M ns a
-mSetAt ns = mUpdateAt ns . const
+-- mSetAt :: Prod Fin ns -> a -> M ns a -> M ns a
+-- mSetAt ns = mUpdateAt ns . const
 
-data Range n l m = Range (IFin ('S n) l) (IFin ('S n) (l + m))
-  deriving (Show, Eq)
+-- data Range n l m = Range (IFin ('S n) l) (IFin ('S n) (l + m))
+--   deriving (Show, Eq)
 
-instance (Known (IFin ('S n)) l, Known (IFin ('S n)) (l + m))
-  => Known (Range n l) m where
-  type KnownC (Range n l) m
-    = (Known (IFin ('S n)) l, Known (IFin ('S n)) (l + m))
-  known = Range known known
+-- instance (Known (IFin ('S n)) l, Known (IFin ('S n)) (l + m))
+--   => Known (Range n l) m where
+--   type KnownC (Range n l) m
+--     = (Known (IFin ('S n)) l, Known (IFin ('S n)) (l + m))
+--   known = Range known known
 
-updateRange :: Range n l m -> (Fin m -> f a -> f a) -> VecT n f a -> VecT n f a
-updateRange = \case
-  Range  IFZ     IFZ    -> \_ -> id
-  Range (IFS l) (IFS m) -> \f -> onTail (updateRange (Range l m) f) \\ m
-  Range  IFZ    (IFS m) -> \f -> onTail (updateRange (Range IFZ m) $ f . FS)
-                               . onHead (f FZ) \\ m
+-- updateRange :: Range n l m -> (Fin m -> f a -> f a) -> VecT n f a -> VecT n f a
+-- updateRange = \case
+--   Range  IFZ     IFZ    -> \_ -> id
+--   Range (IFS l) (IFS m) -> \f -> onTail (updateRange (Range l m) f) \\ m
+--   Range  IFZ    (IFS m) -> \f -> onTail (updateRange (Range IFZ m) $ f . FS)
+--                                . onHead (f FZ) \\ m
 
-setRange :: Range n l m -> VecT m f a -> VecT n f a -> VecT n f a
-setRange r nv = updateRange r (\i _ -> index i nv)
+-- setRange :: Range n l m -> VecT m f a -> VecT n f a -> VecT n f a
+-- setRange r nv = updateRange r (\i _ -> index i nv)
 
-updateSubmatrix
-  :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
-  => Prod (Uncur3 Range) nlms -> (Prod Fin ms -> a -> a) -> M ns a -> M ns a
-updateSubmatrix = \case
-  Ø              -> \f -> (f Ø <$>)
-  Uncur3 r :< rs -> \f -> onMatrix . updateRange r $ \i ->
-    asM . updateSubmatrix rs $ f . (i :<)
+-- updateSubmatrix
+--   :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
+--   => Prod (Uncur3 Range) nlms -> (Prod Fin ms -> a -> a) -> M ns a -> M ns a
+-- updateSubmatrix = \case
+--   Ø              -> \f -> (f Ø <$>)
+--   Uncur3 r :< rs -> \f -> onMatrix . updateRange r $ \i ->
+--     asM . updateSubmatrix rs $ f . (i :<)
 
-setSubmatrix
-  :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
-  => Prod (Uncur3 Range) nlms -> M ms a -> M ns a -> M ns a
-setSubmatrix rs sm = updateSubmatrix rs $ \is _ -> mIndex is sm
+-- setSubmatrix
+--   :: (ns ~ Fsts3 nlms, ms ~ Thds3 nlms)
+--   => Prod (Uncur3 Range) nlms -> M ms a -> M ns a -> M ns a
+-- setSubmatrix rs sm = updateSubmatrix rs $ \is _ -> mIndex is sm
+
+
+-----------
+-- Peano --
+-----------
+
+$(singletons [d|
+
+  data Peano = Z | S Peano deriving (Eq, Ord, Show)
+
+  addPeano :: Peano -> Peano -> Peano
+  addPeano Z a = a
+  addPeano (S a) b = S (addPeano a b)
+
+  subtractPeano :: Peano -> Peano -> Peano
+  subtractPeano Z _ = Z
+  subtractPeano a Z = a
+  subtractPeano (S a) (S b) = subtractPeano a b
+
+  multPeano :: Peano -> Peano -> Peano
+  multPeano Z _ = Z
+  multPeano (S a) b = addPeano (multPeano a b) b
+
+  -- fromIntegerPeano :: Integer -> Peano
+  -- fromIntegerPeano n = if n <= 0 then Z else S (fromIntegerPeano (n - 1))
+
+  -- fromNatPeano :: forall (n :: Nat). Sing n -> Peano
+  -- fromNatPeano n = Z
+
+  instance Num Peano where
+    (+) = addPeano
+
+    (-) = subtractPeano
+
+    (*) = multPeano
+
+    abs = id
+
+    signum Z = Z
+    signum (S _) = S Z
+
+    fromInteger _ = error "fromInteger for Peano not supported"
+
+  |])
+
+-- instance Num Peano where
+--   (+) = addPeano
+
+--   (-) = subtractPeano
+
+--   (*) = multPeano
+
+--   abs = id
+
+--   signum Z = Z
+--   signum (S _) = S Z
+
+  -- fromInteger = fromIntegerPeano
+
+---------
+-- Vec --
+---------
+
+test :: Peano
+test = addPeano Z Z
+
+data Vec (n :: Peano) :: Type -> Type where
+  EmptyVec :: Vec 'Z a
+  VecCons :: !a -> !(Vec n a) -> Vec ('S n) a
+
+-- | Infix operator for 'VecCons'.
+(*:) :: a -> Vec n a -> Vec ('S n) a
+(*:) = VecCons
+
+infixr 4 *:

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -500,6 +500,13 @@ myMat3 = mgen'' sing f
     f :: HList Fin '[N2, N3] -> Int
     f (HListCons f1 (HListCons f2 EmptyHList)) = fin f1 * 3 + fin f2
 
+mgen_ :: SingI ns => (HList Fin ns -> a) -> Matrix ns a
+mgen_ = mgen'' sing
+
+mindex :: HList Fin ns -> Matrix ns a -> a
+mindex EmptyHList (Matrix a) = a
+mindex (HListCons i is) (Matrix vec) = mindex is $ Matrix (vindex i vec)
+
 ----------------------
 -- Matrix Instances --
 ----------------------
@@ -520,6 +527,19 @@ instance SingI ns => Data.Foldable.Foldable (Matrix ns) where
 
   toList :: Matrix ns a -> [a]
   toList = toListMatrix (sing @_ @ns)
+
+instance SingI ns => Distributive (Matrix ns) where
+  distribute :: Functor f => f (Matrix ns a) -> Matrix ns (f a)
+  distribute = distributeRep
+
+instance SingI ns => Representable (Matrix ns) where
+  type Rep (Matrix ns) = HList Fin ns
+
+  tabulate :: (HList Fin ns -> a) -> Matrix ns a
+  tabulate = mgen_
+
+  index :: Matrix ns a -> HList Fin ns -> a
+  index = flip mindex
 
 instance Num a => Num (Matrix '[] a) where
   Matrix a + Matrix b = Matrix (a + b)

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -25,7 +25,9 @@ module Termonad.Config.Vec
 
 import Termonad.Prelude hiding ((\\), index)
 
+import Data.Distributive (Distributive(distribute))
 import qualified Data.Foldable as Data.Foldable
+import Data.Functor.Rep (Representable(..), distributeRep)
 import Data.Kind (Type)
 import Data.Singletons.Prelude
 import Data.Singletons.Prelude.List
@@ -328,6 +330,19 @@ deriving instance Show a => Show (Vec n a)
 deriving instance Functor (Vec n)
 deriving instance Foldable (Vec n)
 
+instance SingI n => Distributive (Vec n) where
+  distribute :: Functor f => f (Vec n a) -> Vec n (f a)
+  distribute = distributeRep
+
+instance SingI n => Representable (Vec n) where
+  type Rep (Vec n) = Fin n
+
+  tabulate :: (Fin n -> a) -> Vec n a
+  tabulate = vgen_
+
+  index :: Vec n a -> Fin n -> a
+  index = flip vindex
+
 type instance Element (Vec n a) = a
 
 -- | Infix operator for 'VecCons'.
@@ -341,6 +356,10 @@ vgen_ = vgen sing
 vgen :: SPeano n -> (Fin n -> a) -> Vec n a
 vgen SZ _ = EmptyVec
 vgen (SS n) f = f FZ :* vgen n (f . FS)
+
+vindex :: Fin n -> Vec n a -> a
+vindex FZ (VecCons a _) = a
+vindex (FS n) (VecCons _ vec) = vindex n vec
 
 ------------
 -- Matrix --

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -475,6 +475,11 @@ mgen'' (SCons (n :: SPeano foo) (ns' :: Sing oaoa)) f =
     byebye :: Fin foo -> HList Fin oaoa -> a
     byebye faaa = f . HListCons faaa
 
+myMat3 :: Matrix '[N2, N3] Int
+myMat3 = mgen'' sing f
+  where
+    f :: HList Fin '[N2, N3] -> Int
+    f (HListCons f1 (HListCons f2 EmptyHList)) = fin f1 * 3 + fin f2
 
 ----------------------
 -- Matrix Instances --

--- a/src/Termonad/Config/Vec.hs
+++ b/src/Termonad/Config/Vec.hs
@@ -312,41 +312,16 @@ type family MatrixTF (ns :: [Peano]) (a :: Type) :: Type where
   MatrixTF '[] a = a
   MatrixTF (n ': ns) a = Vec n (Matrix ns a)
 
--- data MatrixTFSym1 (l :: TyFun
---                       [a6989586621679682896] a6989586621679682896)
---   = forall a1 (arg :: [a1]).
---     SameKind (Apply HeadSym0 arg) (HeadSym1 arg) =>
---     Data.Singletons.Prelude.List.HeadSym0KindInference
---   	-- Defined in ‘Data.Singletons.Prelude.List’
--- type instance Apply HeadSym0 l = Head l
---   	-- Defined in ‘Data.Singletons.Prelude.List’
-    --
-    --
-
--- type role MapSym0 phantom
-
--- data MapSym0 (l :: TyFun
---                      (TyFun a6989586621679662939 b6989586621679662940 -> *)
---                      (TyFun [a6989586621679662939] [b6989586621679662940] -> *))
---   = forall a1 b1 (arg :: TyFun a1 b1 -> *).
---     SameKind (Apply MapSym0 arg) (MapSym1 arg) =>
---     Data.Singletons.Prelude.Base.MapSym0KindInference
-
--- type instance Apply MapSym0 l = MapSym1 l
-
--- type role MapSym1 phantom phantom
-
--- data MapSym1 (l :: TyFun a b -> Type) (l1 :: TyFun [a] [b])
---   = forall (arg :: [a]).  SameKind (Apply (MapSym1 l) arg) (MapSym2 l arg) => MapSym1KindInference
-
--- type instance Apply (MapSym1 l1) l2 = Map l1 l2
-
-
 newtype Matrix ns a = Matrix
   { unMatrix :: MatrixTF ns a
   } deriving anyclass (MonoFoldable)
 
 type instance Element (Matrix ns a) = a
+
+
+---------------------------------
+-- Defunctionalization Symbols --
+---------------------------------
 
 type MatrixTFSym2 (ns :: [Peano]) (t :: Type) = (MatrixTF ns t :: Type)
 
@@ -364,6 +339,9 @@ type instance Apply MatrixTFSym0 l = MatrixTFSym1 l
 
 type role MatrixTFSym1 phantom phantom
 
+----------------------
+-- Matrix Functions --
+----------------------
 
 eqSingMatrix :: forall (peanos :: [Peano]) (a :: Type). Eq a => Sing peanos -> Matrix peanos a -> Matrix peanos a -> Bool
 eqSingMatrix = compareSingMatrix (==) True (&&)
@@ -411,6 +389,10 @@ toListMatrix SNil (Matrix a) = [a]
 toListMatrix (SCons SZ _) (Matrix EmptyVec) = []
 toListMatrix (SCons (SS peanoSingle) moreN) (Matrix (VecCons a moreA)) =
   toListMatrix moreN a <> toListMatrix (SCons peanoSingle moreN) (Matrix moreA)
+
+----------------------
+-- Matrix Instances --
+----------------------
 
 deriving instance (Eq (MatrixTF ns a)) => Eq (Matrix ns a)
 

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -10,9 +10,6 @@ packages:
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
     - gi-vte-2.91.19
-    # This is for https://github.com/cdepillabout/termonad/pull/36.
-    - git: https://github.com/kylcarte/type-combinators.git
-      commit: 071942730b6bb34990d37e1a25236382cf0dcbc6
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -67,12 +67,17 @@ library
                      , lens
                      , pretty-simple
                      , QuickCheck
-                     , type-combinators
+                     , singletons
                      , xml-conduit
                      , xml-html-qq
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds
+                     , DefaultSignatures
+                     , DeriveFoldable
+                     , DeriveFunctor
+                     , EmptyCase
+                     , ExistentialQuantification
                      , FlexibleContexts
                      , FlexibleInstances
                      , GADTs
@@ -83,20 +88,18 @@ library
                      , MultiParamTypeClasses
                      , NamedFieldPuns
                      , NoImplicitPrelude
-                     , OverloadedStrings
                      , OverloadedLabels
                      , OverloadedLists
+                     , OverloadedStrings
                      , PatternSynonyms
                      , PolyKinds
                      , RankNTypes
                      , RecordWildCards
                      , ScopedTypeVariables
+                     , StandaloneDeriving
                      , TypeApplications
                      , TypeFamilies
                      , TypeOperators
-                     , DeriveFunctor
-                     , DeriveFoldable
-                     , StandaloneDeriving
   other-extensions:    TemplateHaskell
                      , UndecidableInstances
   pkgconfig-depends:   gtk+-3.0
@@ -158,18 +161,19 @@ test-suite termonad-test
   other-extensions:    TemplateHaskell
 
 executable termonad-readme
-  main-is:        README.lhs
-  hs-source-dirs: test/readme
-  build-depends:  base
-                  , markdown-unlit
-                  , termonad
-                  , colour
-  ghc-options: -pgmL markdown-unlit
+  main-is:             README.lhs
+  hs-source-dirs:      test/readme
+  build-depends:       base
+                     , markdown-unlit
+                     , termonad
+                     , colour
+  ghc-options:         -pgmL markdown-unlit
+  default-language:    Haskell2010
 
   if flag(buildreadme)
-    buildable:       True
+    buildable:         True
   else
-    buildable:       False
+    buildable:         False
 
 source-repository head
   type:     git

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -74,8 +74,10 @@ library
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds
                      , DefaultSignatures
+                     , DeriveAnyClass
                      , DeriveFoldable
                      , DeriveFunctor
+                     , DerivingStrategies
                      , EmptyCase
                      , ExistentialQuantification
                      , FlexibleContexts

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -50,11 +50,13 @@ library
                      , Termonad.XML
   other-modules:       Paths_termonad
   build-depends:       base >= 4.7 && < 5
+                     , adjunctions
                      , classy-prelude
                      , colour
                      , constraints
                      , data-default
                      , directory >= 1.3.1.0
+                     , distributive
                      , dyre
                      , filepath
                      , gi-gdk


### PR DESCRIPTION
This PR removes the dependency on type-combinators and instead implements everything within Termonad.

I've only implemented a small fraction of the functionality from type-combinators, but it works for now.

This is for #63.  I still need to go back and update the documentation, readme, and haddocks with these new functions and types.