### PR TITLE
Update docs for ColourConfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,9 @@ import Termonad.Config
   , defaultTMConfig, fontConfig, fontFamily, fontSize, options, showScrollbar
   )
 import Termonad.Config.Colour
-  ( ColourConfig, addColourExtension, cursorBgColour, defaultColourConfig )
+  (ColourConfig, addColourExtension, createColourExtension, cursorBgColour
+  , defaultColourConfig
+  )
 
 -- | This sets the color of the cursor in the terminal.
 --
@@ -267,6 +269,7 @@ fontConf =
 
 main :: IO ()
 main = do
+  colExt <- createColourExtension colConf
   let termonadConf =
         defaultTMConfig
           { options =
@@ -276,8 +279,8 @@ main = do
                 , showScrollbar = ShowScrollbarAlways
                 }
           }
-  termonadConfWithColours <- addColourExtension colConf termonadConf
-  defaultMain termonadConfWithColours
+        `addColourExtension` colExt
+  defaultMain termonadConf
 ```
 
 ### Compiling Local Settings

--- a/example-config/ExampleColourExtension.hs
+++ b/example-config/ExampleColourExtension.hs
@@ -1,11 +1,27 @@
+-- | This is an example Termonad configuration that shows how to use the
+-- 'ColourExtension' to set colours for your terminal.  See the project-wide
+-- README.md for how to use Termonad Haskell configuration scripts.
 
 module Main where
 
 import Termonad
+  ( CursorBlinkMode(CursorBlinkModeOff), Option(Set)
+  , ShowScrollbar(ShowScrollbarNever), TMConfig, confirmExit, cursorBlinkMode
+  , defaultConfigOptions, defaultTMConfig, options, showMenu, showScrollbar
+  , start
+  )
 import Termonad.Config.Colour
+  ( Colour, ColourConfig, Palette(BasicPalette), addColourExtension
+  , createColourExtension, cursorBgColour, defaultColourConfig, foregroundColour
+  , palette, sRGB24
+  )
 import Termonad.Config.Vec (Vec((:*), EmptyVec), N8)
 import Data.Colour.SRGB (Colour, sRGB24)
 
+-- This is our main 'TMConfig'.  It holds all of the non-colour settings
+-- for Termonad.
+--
+-- This shows how a few settings can be changed.
 myTMConfig :: TMConfig
 myTMConfig =
   defaultTMConfig
@@ -18,25 +34,39 @@ myTMConfig =
           }
     }
 
+-- This is our 'ColourConfig'.  It holds all of our colour-related settings.
 myColourConfig :: ColourConfig (Colour Double)
-myColourConfig = defaultColourConfig
-  { cursorBgColour = Set (sRGB24 120 80 110) -- purple
-  , foregroundColour = sRGB24 220 180 210 -- light pink
-  , palette = BasicPalette myStandardColours
-  } where
-      myStandardColours :: Vec N8 (Colour Double)
-      myStandardColours =
-           sRGB24  40  30  20 -- dark brown (used as background colour)
-        :* sRGB24 180  30  20 -- red
-        :* sRGB24  40 160  20 -- green
-        :* sRGB24 180 160  20 -- dark yellow
-        :* sRGB24  40  30 120 -- dark purple
-        :* sRGB24 180  30 120 -- bright pink
-        :* sRGB24  40 160 120 -- teal
-        :* sRGB24 180 160 120 -- light brown
-        :* EmptyVec
+myColourConfig =
+  defaultColourConfig
+    -- Set the cursor background colour.  This is the normal colour of the
+    -- cursor.
+    { cursorBgColour = Set (sRGB24 120 80 110) -- purple
+    -- Set the default foreground colour of text of the terminal.
+    , foregroundColour = sRGB24 220 180 210 -- light pink
+    -- Set the basic palette that has 8 colours.
+    , palette = BasicPalette myStandardColours
+    }
+  where
+    -- This is a length-indexed linked-list of colours.
+    myStandardColours :: Vec N8 (Colour Double)
+    myStandardColours =
+         sRGB24  40  30  20 -- dark brown (used as background colour)
+      :* sRGB24 180  30  20 -- red
+      :* sRGB24  40 160  20 -- green
+      :* sRGB24 180 160  20 -- dark yellow
+      :* sRGB24  40  30 120 -- dark purple
+      :* sRGB24 180  30 120 -- bright pink
+      :* sRGB24  40 160 120 -- teal
+      :* sRGB24 180 160 120 -- light brown
+      :* EmptyVec
 
 main :: IO ()
 main = do
+  -- First, create the colour extension based on 'myColourConfig'.
   myColourExt <- createColourExtension myColourConfig
-  start (addColourExtension myTMConfig myColourExt)
+
+  -- Update 'myTMConfig' with our colour extension.
+  let newTMConfig = addColourExtension myTMConfig myColourExt
+
+  -- Start Termonad with our updated 'TMConfig'.
+  start newTMConfig

--- a/example-config/ExampleColourExtension.hs
+++ b/example-config/ExampleColourExtension.hs
@@ -1,0 +1,42 @@
+
+module Main where
+
+import Termonad
+import Termonad.Config.Colour
+import Termonad.Config.Vec (Vec((:*), EmptyVec), N8)
+import Data.Colour.SRGB (Colour, sRGB24)
+
+myTMConfig :: TMConfig
+myTMConfig =
+  defaultTMConfig
+    { options =
+        defaultConfigOptions
+          { showScrollbar = ShowScrollbarNever
+          , confirmExit = False
+          , showMenu = False
+          , cursorBlinkMode = CursorBlinkModeOff
+          }
+    }
+
+myColourConfig :: ColourConfig (Colour Double)
+myColourConfig = defaultColourConfig
+  { cursorBgColour = Set (sRGB24 120 80 110) -- purple
+  , foregroundColour = sRGB24 220 180 210 -- light pink
+  , palette = BasicPalette myStandardColours
+  } where
+      myStandardColours :: Vec N8 (Colour Double)
+      myStandardColours =
+           sRGB24  40  30  20 -- dark brown (used as background colour)
+        :* sRGB24 180  30  20 -- red
+        :* sRGB24  40 160  20 -- green
+        :* sRGB24 180 160  20 -- dark yellow
+        :* sRGB24  40  30 120 -- dark purple
+        :* sRGB24 180  30 120 -- bright pink
+        :* sRGB24  40 160 120 -- teal
+        :* sRGB24 180 160 120 -- light brown
+        :* EmptyVec
+
+main :: IO ()
+main = do
+  myColourExt <- createColourExtension myColourConfig
+  start (addColourExtension myTMConfig myColourExt)

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -10,10 +10,44 @@
 -- To use this config extension in your @~/.config/termonad/termonad.hs@, first
 -- import this module. Create a new 'ColourExtension' with the 'createColourExtension' function.
 -- Then add the 'ColourExtension' to your 'TMConfig' with the 'addColourExtension' function.
--- 
+--
 -- See < this code> for a simple example.
 
-module Termonad.Config.Colour where
+module Termonad.Config.Colour
+  ( -- * Colour Config
+      ColourConfig(..)
+    , defaultColourConfig
+    -- ** Colour Config Lenses
+    , lensCursorFgColour
+    , lensCursorBgColour
+    , lensForegroundColour
+    , lensBackgroundColour
+    , lensPalette
+    -- * Colour Extension
+    , ColourExtension(..)
+    , createColourExtension
+    , createDefColourExtension
+    , addColourExtension
+    , addColourConfig
+    , colourHook
+    , addColourHook
+    -- * Palette
+    , Palette(..)
+    , defaultStandardColours
+    , defaultLightColours
+    , defaultColourCube
+    , defaultGreyscale
+    -- * Colour
+    , Colour
+    , sRGB24
+    , sRGB24show
+    -- * Debugging and Internal Methods
+    , showColourVec
+    , showColourCube
+    , paletteToList
+    , coloursFromBits
+    , cube
+  ) where
 
 import Termonad.Prelude hiding ((\\), index)
 

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -8,45 +8,10 @@
 -- Portability : POSIX
 --
 -- To use this config extension in your @~/.config/termonad/termonad.hs@, first
--- import this module. Then you can simply add the new configuration options to
--- an existing 'TMConfig' with the '<+>' operator, though note that the
--- 'TMConfig' must come first (any other way is a type error).
---
--- E.g.
---
--- > import "Termonad
--- > import "Termonad.Config.Colour"
--- > import "Termonad.Config.Vec" ('Vec', 'VecT'((':+'), 'N8', 'EmptyV'))
--- > import "Data.Colour.SRGB" ('Colour', 'sRGB24')
--- >
--- > myBasicConfig :: 'TMConfig'
--- > myBasicConfig = 'defaultTMConfig'
--- >   { 'showScrollbar' = 'ShowScrollbarNever'
--- >   , 'confirmExit' = False
--- >   , 'showMenu' = False
--- >   , 'cursorBlinkMode' = 'CursorBlinkModeOff'
--- >   }
--- >
--- > myColourConfig :: 'ColourConfig' ('Colour' Double)
--- > myColourConfig = 'defaultColourConfig'
--- >   { 'cursorBgColour' = 'Set' ('sRGB24' 120 80 110)
--- >   , 'foregroundColour' = 'sRGB24' 220 180 210
--- >   , 'palette' = 'BasicPalette' myStandardColours
--- >   } where
--- >       myStandardColours :: 'Vec' 'N8' ('Colour' Double)
--- >       myStandardColours
--- >         =  'sRGB24'  40  30  20
--- >         ':+' 'sRGB24' 180  30  20
--- >         ':+' 'sRGB24'  40 160  20
--- >         ':+' 'sRGB24' 180 160  20
--- >         ':+' 'sRGB24'  40  30 120
--- >         ':+' 'sRGB24' 180  30 120
--- >         ':+' 'sRGB24'  40 160 120
--- >         ':+' 'sRGB24' 180 160 120
--- >         ':+' 'EmptyV'
--- >
--- > main :: IO ()
--- > main = start (myBasicConfig <+> myColourConfig)
+-- import this module. Create a new 'ColourExtension' with the 'createColourExtension' function.
+-- Then add the 'ColourExtension' to your 'TMConfig' with the 'addColourExtension' function.
+-- 
+-- See < this code> for a simple example.
 
 module Termonad.Config.Colour where
 
@@ -472,14 +437,15 @@ createColourExtension conf = do
 createDefColourExtension :: IO ColourExtension
 createDefColourExtension = createColourExtension defaultColourConfig
 
-addColourExtension :: ColourConfig (Colour Double) -> TMConfig -> IO TMConfig
-addColourExtension colConf tmConf = do
+addColourConfig :: TMConfig -> ColourConfig (Colour Double) -> IO TMConfig
+addColourConfig tmConf colConf = do
   ColourExtension _ newHook <- createColourExtension colConf
   let newTMConf = tmConf & lensHooks . lensCreateTermHook %~ addColourHook newHook
   pure newTMConf
 
-addDefColourExtension :: TMConfig -> IO TMConfig
-addDefColourExtension = addColourExtension defaultColourConfig
+addColourExtension :: TMConfig -> ColourExtension -> TMConfig
+addColourExtension tmConf (ColourExtension _ newHook) =
+  tmConf & lensHooks . lensCreateTermHook %~ addColourHook newHook
 
 -- | This function shows how to combine 'createTermHook's.
 --

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -27,10 +27,13 @@ custom-setup
                    , Cabal
                    , cabal-doctest >=1.0.2 && <1.1
 
--- This flag builds the example code from the README.md file.  It is only used
--- for testing.  It should be enabled for CI.
-flag buildreadme
-  description: Build an executable from the example from the README.md file
+-- This flag builds the example code in the example-config/ directory, as well
+-- as the example from the README.md file.  It is only used for testing.  It
+-- should be enabled for CI.
+flag buildexamples
+  description: Build an executable from the examples in the example-config/
+               directory, as well as the example from the README.md file.  This
+               is normally only used for testing.
   default:     False
 
 library
@@ -174,7 +177,19 @@ executable termonad-readme
   ghc-options:         -pgmL markdown-unlit
   default-language:    Haskell2010
 
-  if flag(buildreadme)
+  if flag(buildexamples)
+    buildable:         True
+  else
+    buildable:         False
+
+executable termonad-example-colour-extension
+  main-is:             example-config/ExampleColourExtension.hs
+  build-depends:       base
+                     , termonad
+                     , colour
+  default-language:    Haskell2010
+
+  if flag(buildexamples)
     buildable:         True
   else
     buildable:         False


### PR DESCRIPTION
This adds some docs for the ColourExtension.  It also moves an example of using the ColourExtension from the Haddocks to an actual example file.