### PR TITLE
FocusList implemented with Sequences

### DIFF
--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -279,6 +279,12 @@ emptyFL =
 -- False
 --
 -- Any 'FocusList' with a 'Focus' should never be empty.
+--
+-- prop> hasFocusFL fl ==> not (isEmptyFL fl)
+--
+-- The opposite is also true.
+--
+-- prop> withMaxSuccess 10 (isEmptyFL fl ==> not (hasFocusFL fl))
 isEmptyFL :: FocusList a -> Bool
 isEmptyFL fl = (lengthFL fl) == 0
 

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -8,8 +8,10 @@ import Termonad.Prelude
 
 import Control.Lens
 import qualified Data.Foldable as Foldable
+import qualified Data.OSTree as T
 import Test.QuickCheck
 import Text.Show (Show(showsPrec), ShowS, showParen, showString)
+
 
 -- $setup
 -- >>> :set -XFlexibleContexts

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -114,9 +114,11 @@ instance Show a => Show (FocusList a) where
       showString " " .
       showsPrec 11 (toList focusList)
 
--- lensFocusListAt :: Int -> Lens' (FocusList a) (Maybe a)
--- lensFocusListAt i = lensFocusList . (ix i %~)
-
+-- | Return the length of a 'FocusList'.
+--
+-- >>> let Just fl = flFromList (Focus 2) ["hello", "bye", "parrot"]
+-- >>> lengthFL fl
+-- 3
 lengthFL :: FocusList a -> Int
 lengthFL = S.length . focusList
 
@@ -157,13 +159,20 @@ invariantFL fl =
         NoFocus -> len == 0
 
 -- | Unsafely create a 'FocusList'.  This does not check that the focus
--- actually exists in the list.
+-- actually exists in the list.  This is an internal function and should
+-- generally not be used.  It is only safe to use if you ALREADY know
+-- the 'Focus' is within the list.
 --
 -- >>> unsafeFLFromList (Focus 1) [0..2]
 -- FocusList (Focus 1) [0,1,2]
 --
 -- >>> unsafeFLFromList NoFocus []
 -- FocusList NoFocus []
+--
+-- This allows you create a 'FocusList' that does not pass 'invariantFL'.
+--
+-- >>> unsafeFLFromList (Focus 100) [0..2]
+-- FocusList (Focus 100) [0,1,2]
 unsafeFLFromList :: Focus -> [a] -> FocusList a
 unsafeFLFromList focus list =
   FocusList

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -498,7 +498,7 @@ appendFL fl a =
 --
 -- The 'Focus' will always be updated after calling 'appendSetFocusFL'.
 --
--- prop> (appendSetFocusFL fl a) ^. lensFocusListFocus /= fl ^. lensFocusListFocus
+-- prop> getFocusFL (appendSetFocusFL fl a) > getFocusFL fl
 --
 -- /complexity/: @O(log n)@ where @n@ is the length of the 'FocusList'.
 appendSetFocusFL :: FocusList a -> a -> FocusList a
@@ -523,7 +523,7 @@ appendSetFocusFL fl a =
 --
 -- Prepending to a 'FocusList' will always update the 'Focus':
 --
--- prop> (fl ^. lensFocusListFocus) < (prependFL a fl ^. lensFocusListFocus)
+-- prop> getFocusFL fl < getFocusFL (prependFL a fl)
 --
 -- /complexity/: @O(1)@
 prependFL :: a -> FocusList a -> FocusList a

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -341,8 +341,11 @@ prependFL :: a -> FocusList a -> FocusList a
 prependFL a fl@FocusList{ focusListFocus = focus, focusList = fls}  =
   case focus of
     NoFocus -> singletonFL a
-    Focus i   -> fl {focusListFocus = Focus (i+1)
-                    , focusList = a S.<| fls}
+    Focus i ->
+      fl
+        { focusListFocus = Focus (i+1)
+        , focusList = a S.<| fls
+        }
 
 -- | Unsafely get the 'Focus' from a 'FocusList'.  If the 'Focus' is
 -- 'NoFocus', this function returns 'error'.

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -95,7 +95,7 @@ genValidFL genA = do
         (_:_) -> do
           let listLen = length arbList
           len <- choose (0, listLen - 1)
-          pure $ unsafeFLFromList (Focus len) arbList
+          pure $ unsafeFromListFL (Focus len) arbList
 
 instance Arbitrary1 FocusList where
   liftArbitrary = genValidFL
@@ -163,18 +163,24 @@ invariantFL fl =
 -- generally not be used.  It is only safe to use if you ALREADY know
 -- the 'Focus' is within the list.
 --
--- >>> unsafeFLFromList (Focus 1) [0..2]
+-- Instead, you should generally use 'fromListFL'.
+--
+-- The following is an example of using 'unsafeFromListFL' correctly.
+--
+-- >>> unsafeFromListFL (Focus 1) [0..2]
 -- FocusList (Focus 1) [0,1,2]
 --
--- >>> unsafeFLFromList NoFocus []
+-- >>> unsafeFromListFL NoFocus []
 -- FocusList NoFocus []
 --
--- This allows you create a 'FocusList' that does not pass 'invariantFL'.
+-- 'unsafeFromListFL' can also be used uncorrectly.  The following is an
+-- example of 'unsafeFromListFL' allowing you to create a 'FocusList' that does
+-- not pass 'invariantFL'.
 --
--- >>> unsafeFLFromList (Focus 100) [0..2]
+-- >>> unsafeFromListFL (Focus 100) [0..2]
 -- FocusList (Focus 100) [0,1,2]
-unsafeFLFromList :: Focus -> [a] -> FocusList a
-unsafeFLFromList focus list =
+unsafeFromListFL :: Focus -> [a] -> FocusList a
+unsafeFromListFL focus list =
   FocusList
     { focusListFocus = focus
     , focusList = S.fromList list
@@ -399,38 +405,38 @@ insertFL i a fl@FocusList{focusListFocus = Focus focus, focusList = fls} =
 -- For example, if the 'Focus' is on index 1, and we have removed index 2, then
 -- the focus is not affected, so it is not changed.
 --
--- >>> let focusList = unsafeFLFromList (Focus 1) ["cat","goat","dog","hello"]
+-- >>> let focusList = unsafeFromListFL (Focus 1) ["cat","goat","dog","hello"]
 -- >>> removeFL 2 focusList
 -- Just (FocusList (Focus 1) ["cat","goat","hello"])
 --
 -- If the 'Focus' is on index 2 and we have removed index 1, then the 'Focus'
 -- will be moved back one element to set to index 1.
 --
--- >>> let focusList = unsafeFLFromList (Focus 2) ["cat","goat","dog","hello"]
+-- >>> let focusList = unsafeFromListFL (Focus 2) ["cat","goat","dog","hello"]
 -- >>> removeFL 1 focusList
 -- Just (FocusList (Focus 1) ["cat","dog","hello"])
 --
 -- If we remove the 'Focus', then the next item is set to have the 'Focus'.
 --
--- >>> let focusList = unsafeFLFromList (Focus 0) ["cat","goat","dog","hello"]
+-- >>> let focusList = unsafeFromListFL (Focus 0) ["cat","goat","dog","hello"]
 -- >>> removeFL 0 focusList
 -- Just (FocusList (Focus 0) ["goat","dog","hello"])
 --
 -- If the element to remove is the only element in the list, then the 'Focus'
 -- will be set to 'NoFocus'.
 --
--- >>> let focusList = unsafeFLFromList (Focus 0) ["hello"]
+-- >>> let focusList = unsafeFromListFL (Focus 0) ["hello"]
 -- >>> removeFL 0 focusList
 -- Just (FocusList NoFocus [])
 --
 -- If the 'Int' for the index to remove is either less than 0 or greater then
 -- the length of the list, then 'Nothing' is returned.
 --
--- >>> let focusList = unsafeFLFromList (Focus 0) ["hello"]
+-- >>> let focusList = unsafeFromListFL (Focus 0) ["hello"]
 -- >>> removeFL (-1) focusList
 -- Nothing
 --
--- >>> let focusList = unsafeFLFromList (Focus 1) ["hello","bye","cat"]
+-- >>> let focusList = unsafeFromListFL (Focus 1) ["hello","bye","cat"]
 -- >>> removeFL 3 focusList
 -- Nothing
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -458,7 +458,27 @@ getFocusItemFL fl =
             ") doesnt exist in sequence"
         Just a -> Just a
 
-lookupFL :: Int -> FocusList a -> Maybe a
+-- | Lookup the element at the specified index, counting from 0.
+--
+-- >>> let Just fl = fromListFL (Focus 0) ['a'..'c']
+-- >>> lookupFL 0 fl
+-- Just 'a'
+--
+-- Returns 'Nothing' if the index is out of bounds.
+--
+-- >>> let Just fl = fromListFL (Focus 0) ['a'..'c']
+-- >>> lookupFL 100 fl
+-- Nothing
+-- >>> lookupFL (-1) fl
+-- Nothing
+--
+-- Always returns 'Nothing' if the 'FocusList' is empty.
+--
+-- prop> lookupFL i emptyFL == Nothing
+lookupFL
+  :: Int  -- ^ Index to lookup.
+  -> FocusList a
+  -> Maybe a
 lookupFL i fl = S.lookup i (fl ^. lensFocusList)
 
 -- | Insert a new value into the 'FocusList'.  The 'Focus' of the list is

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -2,7 +2,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
-module Termonad.FocusList where
+module Termonad.FocusList
+  where
 
 import Termonad.Prelude
 
@@ -427,6 +428,19 @@ unsafeGetFocusItemFL fl =
             ") doesnt exist in sequence"
         Just a -> a
 
+-- | Get the item the 'FocusList' is focusing on.  Return 'Nothing' if the
+-- 'FocusList' is empty.
+--
+-- >>> let Just fl = fromListFL (Focus 0) ['a'..'c']
+-- >>> getFocusItemFL fl
+-- Just 'a'
+--
+-- >>> getFocusItemFL emptyFL
+-- Nothing
+--
+-- This will always return 'Just' if there is a 'Focus'.
+--
+-- prop> hasFocusFL fl ==> isJust (getFocusItemFL fl)
 getFocusItemFL :: FocusList a -> Maybe a
 getFocusItemFL fl =
   let focus = fl ^. lensFocusListFocus

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -100,6 +100,8 @@ instance SemiSequence (FocusList a) where
 
   intersperse = intersperseFL
 
+  reverse = reverseFL
+
 
 -- | Given a 'Gen' for @a@, generate a valid 'FocusList'.
 genValidFL :: forall a. Gen a -> Gen (FocusList a)
@@ -824,7 +826,7 @@ moveFromToFL oldPos newPos fl
 --
 -- The item with the 'Focus' should never change after calling 'intersperseFL'.
 --
--- prop> getFocusItemFL fl == getFocusItemFL (intersperseFL a fl)
+-- prop> getFocusItemFL (fl :: FocusList Int) == getFocusItemFL (intersperseFL a fl)
 --
 -- 'intersperseFL' should not have any effect on a 'FocusList' with less than
 -- two items.
@@ -840,3 +842,37 @@ intersperseFL a FocusList{focusList = fls, focusListFocus = Focus foc} =
     { focusList = newFLS
     , focusListFocus = Focus (foc * 2)
     }
+
+-- | Reverse a 'FocusList'.  The 'Focus' is updated accordingly.
+--
+-- >>> let Just fl = fromListFL (Focus 0) ["hello", "bye", "cat"]
+-- >>> reverseFL fl
+-- FocusList (Focus 2) ["cat","bye","hello"]
+--
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "bye", "cat", "goat"]
+-- >>> reverseFL fl
+-- FocusList (Focus 1) ["goat","cat","bye","hello"]
+--
+-- The item with the 'Focus' should never change after calling 'intersperseFL'.
+--
+-- prop> getFocusItemFL (fl :: FocusList Int) == getFocusItemFL (reverseFL fl)
+--
+-- Reversing twice should not change anything.
+--
+-- prop> (fl :: FocusList Int) == reverseFL (reverseFL fl)
+--
+-- Reversing empty lists and single lists should not do anything.
+--
+-- prop> emptyFL == reverseFL emptyFL
+-- prop> singletonFL a == reverseFL (singletonFL a)
+reverseFL :: FocusList a -> FocusList a
+reverseFL FocusList{focusListFocus = NoFocus} = emptyFL
+reverseFL FocusList{focusList = fls, focusListFocus = Focus foc} =
+  let newFLS = reverse fls
+      newFLSLen = length newFLS
+  in
+  FocusList
+    { focusList = newFLS
+    , focusListFocus = Focus (newFLSLen - foc - 1)
+    }
+

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -350,6 +350,32 @@ unsafeGetFLFocus fl =
     NoFocus -> error "unsafeGetFLFocus: the focus list doesn't have a focus"
     Focus i -> i
 
+-- | Return 'True' if the 'Focus' in a 'FocusList' exists.
+--
+-- Return 'False' if the 'Focus' in a 'FocusList' is 'NoFocus'.
+--
+-- >>> hasFocusFL $ singletonFL "hello"
+-- True
+--
+-- >>> hasFocusFL emptyFL
+-- False
+hasFocusFL :: FocusList a -> Bool
+hasFocusFL = hasFocus . getFocusFL
+
+-- | Get the 'Focus' from a 'FocusList'.
+--
+-- >>> getFocusFL $ singletonFL "hello"
+-- Focus 0
+--
+-- >>> let Just fl = fromListFL (Focus 3) [0..9]
+-- >>> getFocusFL fl
+-- Focus 3
+--
+-- >>> getFocusFL emptyFL
+-- NoFocus
+getFocusFL :: FocusList a -> Focus
+getFocusFL FocusList{focusListFocus} = focusListFocus
+
 -- | Unsafely get the value of the 'Focus' from a 'FocusList'.  If the 'Focus' is
 -- 'NoFocus', this function returns 'error'.
 unsafeGetFLFocusItem :: FocusList a -> a

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -55,7 +55,7 @@ unsafeGetFocus (Focus i) = i
 data FocusList a = FocusList
   { focusListFocus :: !Focus
   , focusList :: !(S.Seq  a)
-  } deriving (Eq, Generic)
+  } deriving (Eq, Functor, Generic)
 
 $(makeLensesFor
     [ ("focusListFocus", "lensFocusListFocus")
@@ -63,10 +63,6 @@ $(makeLensesFor
     ]
     ''FocusList
  )
-
-instance Functor FocusList where
-  fmap :: (a -> b) -> FocusList a -> FocusList b
-  fmap f (FocusList focus fls) = FocusList focus (fmap f fls)
 
 instance Foldable FocusList where
   foldr f b (FocusList _ fls) = Foldable.foldr f b fls
@@ -584,7 +580,6 @@ findFL :: (a -> Bool) -> FocusList a -> Maybe (a)
 findFL p fl =
   let fls = fl ^. lensFocusList
   in find p fls
-
 
 -- | Move an existing item in a 'FocusList' to a new index.
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -111,7 +111,6 @@ instance SemiSequence (FocusList a) where
 
   snoc = appendFL
 
-
 -- | Given a 'Gen' for @a@, generate a valid 'FocusList'.
 genValidFL :: forall a. Gen a -> Gen (FocusList a)
 genValidFL genA = do
@@ -238,9 +237,6 @@ unsafeFromListFL focus list =
     { focusListFocus = focus
     , focusList = S.fromList list
     }
-
-focusItemGetter :: Getter (FocusList a) (Maybe a)
-focusItemGetter = to getFocusItemFL
 
 -- | Safely create a 'FocusList' from a list.
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -58,9 +58,6 @@ unsafeGetFocus :: Focus -> Int
 unsafeGetFocus NoFocus = error "unsafeGetFocus: NoFocus"
 unsafeGetFocus (Focus i) = i
 
--- TODO: Probably be better
--- implemented as an Order statistic tree
--- (https://en.wikipedia.org/wiki/Order_statistic_tree).
 data FocusList a = FocusList
   { focusListFocus :: !Focus
   , focusList :: !(S.Seq  a)
@@ -474,16 +471,22 @@ lookupFL i fl = S.lookup i (fl ^. lensFocusList)
 -- >>> insertFL (-1) "bye" (singletonFL "hello")
 -- FocusList (Focus 1) ["bye","hello"]
 insertFL
-  :: Int  -- ^ The index at which to insert the value.
-  -> a
+  :: Int  -- ^ The index at which to insert the new element.
+  -> a    -- ^ The new element.
   -> FocusList a
   -> FocusList a
 insertFL _ a FocusList {focusListFocus = NoFocus} = singletonFL a
 insertFL i a fl@FocusList{focusListFocus = Focus focus, focusList = fls} =
   if i > focus
-  then fl {focusList = S.insertAt i a fls}
-  else fl {focusList = S.insertAt i a fls,
-           focusListFocus = Focus $ focus + 1}
+    then
+      fl
+        { focusList = S.insertAt i a fls
+        }
+    else
+      fl
+        { focusList = S.insertAt i a fls
+        , focusListFocus = Focus $ focus + 1
+        }
 
 -- | Remove an element from a 'FocusList'.
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -13,7 +13,6 @@ import qualified Data.Sequence as S
 import Test.QuickCheck
 import Text.Show (Show(showsPrec), ShowS, showParen, showString)
 
-
 -- $setup
 -- >>> :set -XFlexibleContexts
 -- >>> :set -XScopedTypeVariables
@@ -62,9 +61,14 @@ unsafeGetFocus :: Focus -> Int
 unsafeGetFocus NoFocus = error "unsafeGetFocus: NoFocus"
 unsafeGetFocus (Focus i) = i
 
+-- | A list with a given element having the 'Focus'.
+--
+-- Implemented under the hood as a 'S.Seq'.  The 'FocusList' has some
+-- invariants that must be protected.  You should not use the 'FocusList'
+-- constructor or the 'focusListFocus' or 'focusList' accessors.
 data FocusList a = FocusList
   { focusListFocus :: !Focus
-  , focusList :: !(S.Seq  a)
+  , focusList :: !(S.Seq a)
   } deriving (Eq, Functor, Generic)
 
 $(makeLensesFor

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -116,7 +116,7 @@ instance Show a => Show (FocusList a) where
 
 -- | Return the length of a 'FocusList'.
 --
--- >>> let Just fl = flFromList (Focus 2) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "bye", "parrot"]
 -- >>> lengthFL fl
 -- 3
 lengthFL :: FocusList a -> Int
@@ -185,27 +185,27 @@ focusItemGetter = to getFLFocusItem
 
 -- | Safely create a 'FocusList' from a list.
 --
--- >>> flFromList (Focus 1) ["cat","dog","goat"]
+-- >>> fromListFL (Focus 1) ["cat","dog","goat"]
 -- Just (FocusList (Focus 1) ["cat","dog","goat"])
 --
--- >>> flFromList NoFocus []
+-- >>> fromListFL NoFocus []
 -- Just (FocusList NoFocus [])
 --
 -- If the 'Focus' is out of range for the list, then 'Nothing' will be returned.
 --
--- >>> flFromList (Focus (-1)) ["cat","dog","goat"]
+-- >>> fromListFL (Focus (-1)) ["cat","dog","goat"]
 -- Nothing
 --
--- >>> flFromList (Focus 3) ["cat","dog","goat"]
+-- >>> fromListFL (Focus 3) ["cat","dog","goat"]
 -- Nothing
 --
--- >>> flFromList NoFocus ["cat","dog","goat"]
+-- >>> fromListFL NoFocus ["cat","dog","goat"]
 -- Nothing
-flFromList :: Focus -> [a] -> Maybe (FocusList a)
-flFromList NoFocus [] = Just emptyFL
-flFromList _ [] = Nothing
-flFromList NoFocus (_:_) = Nothing
-flFromList (Focus i) list =
+fromListFL :: Focus -> [a] -> Maybe (FocusList a)
+fromListFL NoFocus [] = Just emptyFL
+fromListFL _ [] = Nothing
+fromListFL NoFocus (_:_) = Nothing
+fromListFL (Focus i) list =
   let len = length list
   in
   if i < 0 || i >= len
@@ -272,7 +272,7 @@ appendFL fl a =
 
 -- | A combination of 'appendFL' and 'setFocusFL'.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "tree"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "tree"]
 -- >>> appendSetFocusFL fl "pie"
 -- FocusList (Focus 3) ["hello","bye","tree","pie"]
 --
@@ -459,19 +459,19 @@ removeFL i fl@FocusList{focusList = fls}
 
 -- | Find the index of the first element in the 'FocusList'.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "tree"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "tree"]
 -- >>> indexOfFL "hello" fl
 -- Just 0
 --
 -- If more than one element exists, then return the index of the first one.
 --
--- >>> let Just fl = flFromList (Focus 1) ["dog", "cat", "cat"]
+-- >>> let Just fl = fromListFL (Focus 1) ["dog", "cat", "cat"]
 -- >>> indexOfFL "cat" fl
 -- Just 1
 --
 -- If the element doesn't exist, then return 'Nothing'
 --
--- >>> let Just fl = flFromList (Focus 1) ["foo", "bar", "baz"]
+-- >>> let Just fl = fromListFL (Focus 1) ["foo", "bar", "baz"]
 -- >>> indexOfFL "hogehoge" fl
 -- Nothing
 indexOfFL :: Eq a => a -> FocusList a -> Maybe Int
@@ -480,25 +480,25 @@ indexOfFL a FocusList{focusList = fls} =
 
 -- | Delete an element from a 'FocusList'.
 --
--- >>> let Just fl = flFromList (Focus 0) ["hello", "bye", "tree"]
+-- >>> let Just fl = fromListFL (Focus 0) ["hello", "bye", "tree"]
 -- >>> deleteFL "bye" fl
 -- FocusList (Focus 0) ["hello","tree"]
 --
 -- The focus will be updated if an item before it is deleted.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "tree"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "tree"]
 -- >>> deleteFL "hello" fl
 -- FocusList (Focus 0) ["bye","tree"]
 --
 -- If there are multiple matching elements in the 'FocusList', remove them all.
 --
--- >>> let Just fl = flFromList (Focus 0) ["hello", "bye", "bye"]
+-- >>> let Just fl = fromListFL (Focus 0) ["hello", "bye", "bye"]
 -- >>> deleteFL "bye" fl
 -- FocusList (Focus 0) ["hello"]
 --
 -- If there are no matching elements, return the original 'FocusList'.
 --
--- >>> let Just fl = flFromList (Focus 2) ["hello", "good", "bye"]
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "good", "bye"]
 -- >>> deleteFL "frog" fl
 -- FocusList (Focus 2) ["hello","good","bye"]
 deleteFL
@@ -540,7 +540,7 @@ setFocusFL i fl
 
 -- | Update the 'Focus' for a 'FocusList' and get the new focused element.
 --
--- >>> updateFocusFL 1 =<< flFromList (Focus 2) ["hello","bye","dog","cat"]
+-- >>> updateFocusFL 1 =<< fromListFL (Focus 2) ["hello","bye","dog","cat"]
 -- Just ("bye",FocusList (Focus 1) ["hello","bye","dog","cat"])
 --
 -- If the 'FocusList' is empty, then return 'Nothing'.
@@ -551,10 +551,10 @@ setFocusFL i fl
 -- If the new focus is less than 0, or greater than or equal to the length of
 -- the 'FocusList', then return 'Nothing'.
 --
--- >>> updateFocusFL (-1) =<< flFromList (Focus 2) ["hello","bye","dog","cat"]
+-- >>> updateFocusFL (-1) =<< fromListFL (Focus 2) ["hello","bye","dog","cat"]
 -- Nothing
 --
--- >>> updateFocusFL 4 =<< flFromList (Focus 2) ["hello","bye","dog","cat"]
+-- >>> updateFocusFL 4 =<< fromListFL (Focus 2) ["hello","bye","dog","cat"]
 -- Nothing
 updateFocusFL :: Int -> FocusList a -> Maybe (a, FocusList a)
 updateFocusFL i fl
@@ -570,19 +570,19 @@ updateFocusFL i fl
 
 -- | Find a value in a 'FocusList'.  Similar to @Data.List.'Data.List.find'@.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "tree"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "tree"]
 -- >>> findFL (\a -> a == "hello") fl
 -- Just "hello"
 --
 -- This will only find the first value.
 --
--- >>> let Just fl = flFromList (Focus 0) ["hello", "bye", "bye"]
+-- >>> let Just fl = fromListFL (Focus 0) ["hello", "bye", "bye"]
 -- >>> findFL (\a -> a == "bye") fl
 -- Just "bye"
 --
 -- If no values match the comparison, this will return 'Nothing'.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "parrot"]
 -- >>> findFL (\a -> a == "ball") fl
 -- Nothing
 findFL :: (a -> Bool) -> FocusList a -> Maybe (a)
@@ -594,31 +594,31 @@ findFL p fl =
 --
 -- The 'Focus' gets updated appropriately when moving items.
 --
--- >>> let Just fl = flFromList (Focus 1) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 1) ["hello", "bye", "parrot"]
 -- >>> moveFromToFL 0 1 fl
 -- Just (FocusList (Focus 0) ["bye","hello","parrot"])
 --
 -- The 'Focus' may not get updated if it is not involved.
 --
--- >>> let Just fl = flFromList (Focus 0) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 0) ["hello", "bye", "parrot"]
 -- >>> moveFromToFL 1 2 fl
 -- Just (FocusList (Focus 0) ["hello","parrot","bye"])
 --
 -- If the element with the 'Focus' is moved, then the 'Focus' will be updated appropriately.
 --
--- >>> let Just fl = flFromList (Focus 2) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "bye", "parrot"]
 -- >>> moveFromToFL 2 0 fl
 -- Just (FocusList (Focus 0) ["parrot","hello","bye"])
 --
 -- If the index of the item to move is out bounds, then 'Nothing' will be returned.
 --
--- >>> let Just fl = flFromList (Focus 2) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "bye", "parrot"]
 -- >>> moveFromToFL 3 0 fl
 -- Nothing
 --
 -- If the new index is out of bounds, then 'Nothing' wil be returned.
 --
--- >>> let Just fl = flFromList (Focus 2) ["hello", "bye", "parrot"]
+-- >>> let Just fl = fromListFL (Focus 2) ["hello", "bye", "parrot"]
 -- >>> moveFromToFL 1 (-1) fl
 -- Nothing
 moveFromToFL

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -73,6 +74,9 @@ import qualified Data.Foldable as Foldable
 import qualified Data.Sequence as S
 import Data.Sequence (Seq((:<|), Empty))
 import Test.QuickCheck
+  ( Arbitrary, Arbitrary1, CoArbitrary, Gen, arbitrary, arbitrary1, choose
+  , frequency, liftArbitrary
+  )
 import Text.Show (Show(showsPrec), ShowS, showParen, showString)
 
 -- $setup

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -107,6 +107,10 @@ instance SemiSequence (FocusList a) where
 
   sortBy = sortByFL
 
+  cons = prependFL
+
+  snoc = appendFL
+
 
 -- | Given a 'Gen' for @a@, generate a valid 'FocusList'.
 genValidFL :: forall a. Gen a -> Gen (FocusList a)

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE NoImplicitPrelude #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE TemplateHaskell #-}
 
@@ -67,12 +66,19 @@ module Termonad.FocusList
   , unsafeGetFocus
   ) where
 
-import Termonad.Prelude
+import Prelude hiding (reverse)
 
 import Control.Lens (Prism', (^.), (.~), (-~), makeLensesFor, prism')
+import Data.Foldable (toList)
 import qualified Data.Foldable as Foldable
+import Data.Function ((&))
+import Data.MonoTraversable
+  (Element, GrowingAppend, MonoFoldable, MonoFunctor, MonoTraversable, olength)
 import qualified Data.Sequence as S
 import Data.Sequence (Seq((:<|), Empty))
+import Data.Sequences
+  (Index, SemiSequence, cons, find, intersperse, reverse, snoc, sortBy)
+import GHC.Generics (Generic)
 import Test.QuickCheck
   ( Arbitrary, Arbitrary1, CoArbitrary, Gen, arbitrary, arbitrary1, choose
   , frequency, liftArbitrary
@@ -82,6 +88,7 @@ import Text.Show (Show(showsPrec), ShowS, showParen, showString)
 -- $setup
 -- >>> :set -XFlexibleContexts
 -- >>> :set -XScopedTypeVariables
+-- >>> import Data.Maybe (isJust)
 
 -- | A 'Focus' for the 'FocusList'.
 --
@@ -213,7 +220,7 @@ $(makeLensesFor
  )
 
 instance Foldable FocusList where
-  foldr f b (FocusList _ fls) = Foldable.foldr f b fls
+  foldr f b (FocusList _ fls) = foldr f b fls
 
   length = lengthFL
 
@@ -427,7 +434,7 @@ fromListFL (Focus i) list =
 --
 -- /complexity/: @O(n)@ where @n@ is the length of the 'Foldable'
 fromFoldableFL :: Foldable f => Focus -> f a -> Maybe (FocusList a)
-fromFoldableFL foc as = fromListFL foc (Foldable.toList as)
+fromFoldableFL foc as = fromListFL foc (toList as)
 
 -- | Create a 'FocusList' with a single element.
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -688,7 +688,7 @@ lookupFL i fl = S.lookup i (fl ^. lensFocusList)
 -- | Insert a new value into the 'FocusList'.  The 'Focus' of the list is
 -- changed appropriately.
 --
--- Inserting an element into an empyt 'FocusList' will set the 'Focus' on
+-- Inserting an element into an empty 'FocusList' will set the 'Focus' on
 -- that element.
 --
 -- >>> insertFL 0 "hello" emptyFL
@@ -874,7 +874,7 @@ deleteFL item = go
 
 -- | Set the 'Focus' for a 'FocusList'.
 --
--- This is just like 'updateFocusFL', but doesn't return the new focused item.
+-- This is just like 'updateFocusFL', but doesn't return the newly focused item.
 --
 -- prop> setFocusFL i fl == fmap snd (updateFocusFL i fl)
 --

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -8,7 +8,7 @@ module Termonad.FocusList
     FocusList(FocusList, focusListFocus, focusList)
     -- ** Conversions
   , fromListFL
-  , fromFoldable
+  , fromFoldableFL
   , toSeqFL
     -- ** Query
   , lengthFL
@@ -136,7 +136,7 @@ _NoFocus = prism' (const NoFocus) (foldFocus (Just ()) (const Nothing))
 -- >>> hasFocus NoFocus
 -- False
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 hasFocus :: Focus -> Bool
 hasFocus NoFocus = False
 hasFocus (Focus _) = True
@@ -149,7 +149,7 @@ hasFocus (Focus _) = True
 -- >>> getFocus NoFocus
 -- Nothing
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 getFocus :: Focus -> Maybe Int
 getFocus NoFocus = Nothing
 getFocus (Focus i) = Just i
@@ -168,7 +168,7 @@ getFocus (Focus i) = Just i
 --
 -- prop> maybeInt == getFocus (maybeToFocus maybeInt)
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 maybeToFocus :: Maybe Int -> Focus
 maybeToFocus Nothing = NoFocus
 maybeToFocus (Just i) = Focus i
@@ -184,16 +184,18 @@ maybeToFocus (Just i) = Focus i
 -- *** Exception: ...
 -- ...
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 unsafeGetFocus :: Focus -> Int
 unsafeGetFocus NoFocus = error "unsafeGetFocus: NoFocus"
 unsafeGetFocus (Focus i) = i
 
 -- | A list with a given element having the 'Focus'.
 --
--- Implemented under the hood as a 'S.Seq'.  The 'FocusList' has some
--- invariants that must be protected.  You should not use the 'FocusList'
--- constructor or the 'focusListFocus' or 'focusList' accessors.
+-- 'FocusList' has some invariants that must be protected.  You should not use
+-- the 'FocusList' constructor or the 'focusListFocus' or 'focusList'
+-- accessors.
+--
+-- Implemented under the hood as a 'S.Seq'.
 data FocusList a = FocusList
   { focusListFocus :: !Focus
   , focusList :: !(S.Seq a)
@@ -278,7 +280,7 @@ instance Show a => Show (FocusList a) where
 
 -- | Get the underlying 'Seq' in a 'FocusList'.
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 toSeqFL :: FocusList a -> Seq a
 toSeqFL FocusList{focusList = fls} = fls
 
@@ -288,7 +290,7 @@ toSeqFL FocusList{focusList = fls} = fls
 -- >>> lengthFL fl
 -- 3
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 lengthFL :: FocusList a -> Int
 lengthFL = S.length . focusList
 
@@ -307,7 +309,7 @@ lengthFL = S.length . focusList
 -- - There needs to be a 'Focus' if the length of the
 --   'FocusList' is greater than 0.
 --
--- @O(log n)@, where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(log n)@, where @n@ is the length of the 'FocusList'.
 invariantFL :: FocusList a -> Bool
 invariantFL fl =
   invariantFocusNotNeg &&
@@ -368,7 +370,7 @@ invariantFL fl =
 -- If 'fromListFL' returns a 'Just' 'FocusList', then 'unsafeFromListFL' should
 -- return the same 'FocusList'.
 --
--- @O(n)@ where @n@ is the length of the input list.
+-- /complexity/: @O(n)@ where @n@ is the length of the input list.
 unsafeFromListFL :: Focus -> [a] -> FocusList a
 unsafeFromListFL focus list =
   FocusList
@@ -395,7 +397,7 @@ unsafeFromListFL focus list =
 -- >>> fromListFL NoFocus ["cat","dog","goat"]
 -- Nothing
 --
--- @O(n)@ where @n@ is the length of the input list.
+-- /complexity/: @O(n)@ where @n@ is the length of the input list.
 fromListFL :: Focus -> [a] -> Maybe (FocusList a)
 fromListFL NoFocus [] = Just emptyFL
 fromListFL _ [] = Nothing
@@ -419,7 +421,7 @@ fromListFL (Focus i) list =
 --
 -- prop> fromFoldableFL foc (foldable :: Data.Sequence.Seq Int) == fromListFL foc (toList foldable)
 --
--- @O(n)@
+-- /complexity/: @O(n)@ where @n@ is the length of the 'Foldable'
 fromFoldableFL :: Foldable f => Focus -> f a -> Maybe (FocusList a)
 fromFoldableFL foc as = fromListFL foc (Foldable.toList as)
 
@@ -428,7 +430,7 @@ fromFoldableFL foc as = fromListFL foc (Foldable.toList as)
 -- >>> singletonFL "hello"
 -- FocusList (Focus 0) ["hello"]
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 singletonFL :: a -> FocusList a
 singletonFL a =
   FocusList
@@ -441,7 +443,7 @@ singletonFL a =
 -- >>> emptyFL
 -- FocusList NoFocus []
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 emptyFL :: FocusList a
 emptyFL =
   FocusList
@@ -463,7 +465,7 @@ emptyFL =
 --
 -- The opposite is also true.
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 isEmptyFL :: FocusList a -> Bool
 isEmptyFL fl = (lengthFL fl) == 0
 
@@ -481,7 +483,7 @@ isEmptyFL fl = (lengthFL fl) == 0
 --
 -- prop> appendFL emptyFL a == singletonFL a
 --
--- @O(log n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(log n)@ where @n@ is the length of the 'FocusList'.
 appendFL :: FocusList a -> a -> FocusList a
 appendFL fl a =
   if isEmptyFL fl
@@ -498,7 +500,7 @@ appendFL fl a =
 --
 -- prop> (appendSetFocusFL fl a) ^. lensFocusListFocus /= fl ^. lensFocusListFocus
 --
--- @O(log n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(log n)@ where @n@ is the length of the 'FocusList'.
 appendSetFocusFL :: FocusList a -> a -> FocusList a
 appendSetFocusFL fl a =
   let oldLen = length $ focusList fl
@@ -523,7 +525,7 @@ appendSetFocusFL fl a =
 --
 -- prop> (fl ^. lensFocusListFocus) < (prependFL a fl ^. lensFocusListFocus)
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 prependFL :: a -> FocusList a -> FocusList a
 prependFL a fl@FocusList{ focusListFocus = focus, focusList = fls}  =
   case focus of
@@ -550,7 +552,7 @@ prependFL a fl@FocusList{ focusListFocus = focus, focusList = fls}  =
 -- *** Exception: ...
 -- ...
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 unsafeGetFocusFL :: FocusList a -> Int
 unsafeGetFocusFL fl =
   let focus = fl ^. lensFocusListFocus
@@ -569,7 +571,7 @@ unsafeGetFocusFL fl =
 -- >>> hasFocusFL emptyFL
 -- False
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 hasFocusFL :: FocusList a -> Bool
 hasFocusFL = hasFocus . getFocusFL
 
@@ -585,7 +587,7 @@ hasFocusFL = hasFocus . getFocusFL
 -- >>> getFocusFL emptyFL
 -- NoFocus
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 getFocusFL :: FocusList a -> Focus
 getFocusFL FocusList{focusListFocus} = focusListFocus
 
@@ -605,7 +607,7 @@ getFocusFL FocusList{focusListFocus} = focusListFocus
 -- *** Exception: ...
 -- ...
 --
--- @O(log(min(i, n - i)))@ where @i@ is the 'Focus', and @n@
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is the 'Focus', and @n@
 -- is the length of the 'FocusList'.
 unsafeGetFocusItemFL :: FocusList a -> a
 unsafeGetFocusItemFL fl =
@@ -638,7 +640,7 @@ unsafeGetFocusItemFL fl =
 --
 -- prop> hasFocusFL fl ==> isJust (getFocusItemFL fl)
 --
--- @O(log(min(i, n - i)))@ where @i@ is the 'Focus', and @n@
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is the 'Focus', and @n@
 -- is the length of the 'FocusList'.
 getFocusItemFL :: FocusList a -> Maybe a
 getFocusItemFL fl =
@@ -675,7 +677,7 @@ getFocusItemFL fl =
 --
 -- prop> lookupFL i emptyFL == Nothing
 --
--- @O(log(min(i, n - i)))@ where @i@ is the index you want to look up, and @n@
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is the index you want to look up, and @n@
 -- is the length of the 'FocusList'.
 lookupFL
   :: Int  -- ^ Index to lookup.
@@ -716,7 +718,7 @@ lookupFL i fl = S.lookup i (fl ^. lensFocusList)
 -- >>> insertFL (-1) "bye" (singletonFL "hello")
 -- FocusList (Focus 1) ["bye","hello"]
 --
--- @O(log(min(i, n - i)))@ where @i@ is the index you want to insert at, and @n@
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is the index you want to insert at, and @n@
 -- is the length of the 'FocusList'.
 insertFL
   :: Int  -- ^ The index at which to insert the new element.
@@ -784,7 +786,7 @@ insertFL i a fl@FocusList{focusListFocus = Focus focus, focusList = fls} =
 -- >>> removeFL 0 emptyFL
 -- Nothing
 --
--- @O(log(min(i, n - i)))@ where @i@ is index of the element to remove, and @n@
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is index of the element to remove, and @n@
 -- is the length of the 'FocusList'.
 removeFL
   :: Int          -- ^ Index of the element to remove from the 'FocusList'.
@@ -876,7 +878,7 @@ deleteFL item = go
 --
 -- prop> setFocusFL i fl == fmap snd (updateFocusFL i fl)
 --
--- @O(1)@
+-- /complexity/: @O(1)@
 setFocusFL :: Int -> FocusList a -> Maybe (FocusList a)
 setFocusFL i fl
   -- Can't set a 'Focus' for an empty 'FocusList'.
@@ -907,7 +909,7 @@ setFocusFL i fl
 -- >>> updateFocusFL 4 =<< fromListFL (Focus 2) ["hello","bye","dog","cat"]
 -- Nothing
 --
--- @O(log(min(i, n - i)))@ where @i@ is the new index to put the 'Focus' on,
+-- /complexity/: @O(log(min(i, n - i)))@ where @i@ is the new index to put the 'Focus' on,
 -- and @n@ -- is the length of the 'FocusList'.
 updateFocusFL
   :: Int  -- ^ The new index to put the 'Focus' on.
@@ -944,7 +946,7 @@ updateFocusFL i fl
 -- >>> findFL (\a -> a == "ball") fl
 -- Nothing
 --
--- @O(n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(n)@ where @n@ is the length of the 'FocusList'.
 findFL :: (a -> Bool) -> FocusList a -> Maybe (a)
 findFL p fl =
   let fls = fl ^. lensFocusList
@@ -983,7 +985,7 @@ findFL p fl =
 -- >>> moveFromToFL 1 (-1) fl
 -- Nothing
 --
--- @O(log n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(log n)@ where @n@ is the length of the 'FocusList'.
 moveFromToFL
   :: Show a
   => Int  -- ^ Index of the item to move.
@@ -1032,7 +1034,7 @@ moveFromToFL oldPos newPos fl
 -- prop> emptyFL == intersperseFL x emptyFL
 -- prop> singletonFL a == intersperseFL x (singletonFL a)
 --
--- @O(n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(n)@ where @n@ is the length of the 'FocusList'.
 intersperseFL :: a -> FocusList a -> FocusList a
 intersperseFL _ FocusList{focusListFocus = NoFocus} = emptyFL
 intersperseFL a FocusList{focusList = fls, focusListFocus = Focus foc} =
@@ -1066,7 +1068,7 @@ intersperseFL a FocusList{focusList = fls, focusListFocus = Focus foc} =
 -- prop> emptyFL == reverseFL emptyFL
 -- prop> singletonFL a == reverseFL (singletonFL a)
 --
--- @O(n)@ where @n@ is the length of the 'FocusList'.
+-- /complexity/: @O(n)@ where @n@ is the length of the 'FocusList'.
 reverseFL :: FocusList a -> FocusList a
 reverseFL FocusList{focusListFocus = NoFocus} = emptyFL
 reverseFL FocusList{focusList = fls, focusListFocus = Focus foc} =

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -7,7 +7,7 @@ module Termonad.FocusList
 
 import Termonad.Prelude
 
-import Control.Lens (Getter, Prism', (^.), (.~), (-~), makeLensesFor, prism', to)
+import Control.Lens (Prism', (^.), (.~), (-~), makeLensesFor, prism')
 import qualified Data.Foldable as Foldable
 import qualified Data.Sequence as S
 import Data.Sequence (Seq((:<|), Empty))

--- a/src/Termonad/FocusList.hs
+++ b/src/Termonad/FocusList.hs
@@ -3,7 +3,68 @@
 {-# LANGUAGE TemplateHaskell #-}
 
 module Termonad.FocusList
-  where
+  (
+    -- * FocusList
+    FocusList(FocusList, focusListFocus, focusList)
+    -- ** Conversions
+  , fromListFL
+  , fromFoldable
+  , toSeqFL
+    -- ** Query
+  , lengthFL
+  , isEmptyFL
+  , getFocusItemFL
+  , lookupFL
+  , indexOfFL
+  , findFL
+    -- *** Query 'Focus'
+  , hasFocusFL
+  , getFocusFL
+    -- ** Manipulate
+  , prependFL
+  , appendFL
+  , appendSetFocusFL
+  , insertFL
+  , removeFL
+  , deleteFL
+  , moveFromToFL
+  , intersperseFL
+  , reverseFL
+    -- *** Manipulate 'Focus'
+  , setFocusFL
+  , updateFocusFL
+    -- ** Sort
+  , sortByFL
+    -- ** Construction
+  , emptyFL
+  , singletonFL
+    -- ** Unsafe Functions
+  , unsafeFromListFL
+  , unsafeGetFocusFL
+  , unsafeGetFocusItemFL
+    -- ** Invariants
+  , invariantFL
+    -- ** Testing
+  , genValidFL
+    -- ** Optics
+    -- | These optics allow you to get/set the internal state of a 'FocusList'.
+    -- You should make sure not to directly set the internal state of a
+    -- 'FocusList' unless you are sure that the invariants for the 'FocusList'
+    -- are protected.  See 'invariantFL'.
+  , lensFocusListFocus
+  , lensFocusList
+    -- * Focus
+  , Focus(Focus, NoFocus)
+    , hasFocus
+    , getFocus
+    , maybeToFocus
+    , foldFocus
+    -- ** Optics
+  , _Focus
+  , _NoFocus
+    -- ** Unsafe Functions
+  , unsafeGetFocus
+  ) where
 
 import Termonad.Prelude
 

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -86,7 +86,7 @@ import System.FilePath ((</>))
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
 
-import Termonad.FocusList (appendFL, deleteFL, getFLFocusItem)
+import Termonad.FocusList (appendFL, deleteFL, getFocusItemFL)
 import Termonad.Lenses
   ( lensConfirmExit
   , lensOptions
@@ -133,7 +133,7 @@ termExitFocused :: TMState -> IO ()
 termExitFocused mvarTMState = do
   tmState <- readMVar mvarTMState
   let maybeTab =
-        tmState ^. lensTMStateNotebook . lensTMNotebookTabs . to getFLFocusItem
+        tmState ^. lensTMStateNotebook . lensTMNotebookTabs . to getFocusItemFL
   case maybeTab of
     Nothing -> pure ()
     Just tab -> termClose tab mvarTMState
@@ -297,7 +297,7 @@ createTerm handleKeyPress mvarTMState = do
   scrolledWin <- createScrolledWin mvarTMState
   TMState{tmStateAppWin, tmStateFontDesc, tmStateConfig, tmStateNotebook=currNote} <-
     readMVar mvarTMState
-  let maybeCurrFocusedTabPid = pid . tmNotebookTabTerm <$> getFLFocusItem (tmNotebookTabs currNote)
+  let maybeCurrFocusedTabPid = pid . tmNotebookTabTerm <$> getFocusItemFL (tmNotebookTabs currNote)
   maybeCurrDir <- maybe (pure Nothing) cwdOfPid maybeCurrFocusedTabPid
   vteTerm <- terminalNew
   terminalSetFont vteTerm (Just tmStateFontDesc)

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -22,7 +22,7 @@ import GI.Vte (Terminal, CursorBlinkMode(CursorBlinkModeOn))
 import Text.Pretty.Simple (pPrint)
 import Text.Show (Show(showsPrec), ShowS, showParen, showString)
 
-import Termonad.FocusList (FocusList, emptyFL, singletonFL, getFLFocusItem, lengthFL)
+import Termonad.FocusList (FocusList, emptyFL, singletonFL, getFocusItemFL, lengthFL)
 import Termonad.Gtk (widgetEq)
 
 -- | A wrapper around a VTE 'Terminal'.  This also stores the process ID of the
@@ -159,7 +159,7 @@ getFocusedTermFromState mvarTMState =
     go :: TMState' -> IO (Maybe Terminal)
     go tmState = do
       let maybeNotebookTab =
-            getFLFocusItem $ tmNotebookTabs $ tmStateNotebook tmState
+            getFocusItemFL $ tmNotebookTabs $ tmStateNotebook tmState
       pure $ fmap (term . tmNotebookTabTerm) maybeNotebookTab
 
 createTMNotebookTab :: Label -> ScrolledWindow -> TMTerm -> TMNotebookTab
@@ -458,7 +458,7 @@ invariantTMState' tmState =
       maybeWidgetFromNote <- notebookGetNthPage tmNote index32
       let focusList = tmNotebookTabs $ tmStateNotebook tmState
           maybeScrollWinFromFL =
-            fmap tmNotebookTabTermContainer $ getFLFocusItem $ focusList
+            fmap tmNotebookTabTermContainer $ getFocusItemFL $ focusList
           idx = fromIntegral index32
       case (maybeWidgetFromNote, maybeScrollWinFromFL) of
         (Nothing, Nothing) -> pure Nothing

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -22,7 +22,7 @@ import GI.Vte (Terminal, CursorBlinkMode(CursorBlinkModeOn))
 import Text.Pretty.Simple (pPrint)
 import Text.Show (Show(showsPrec), ShowS, showParen, showString)
 
-import Termonad.FocusList (FocusList, emptyFL, singletonFL, getFLFocusItem, focusListLen)
+import Termonad.FocusList (FocusList, emptyFL, singletonFL, getFLFocusItem, lengthFL)
 import Termonad.Gtk (widgetEq)
 
 -- | A wrapper around a VTE 'Terminal'.  This also stores the process ID of the
@@ -484,7 +484,7 @@ invariantTMState' tmState =
       let tmNote = tmNotebook $ tmStateNotebook tmState
       noteLength32 <- notebookGetNPages tmNote
       let noteLength = fromIntegral noteLength32
-          focusListLength = focusListLen $ tmNotebookTabs $ tmStateNotebook tmState
+          focusListLength = lengthFL $ tmNotebookTabs $ tmStateNotebook tmState
           lengthEqual = focusListLength == noteLength
       if lengthEqual
         then pure Nothing

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -9,8 +9,6 @@ packages:
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
     - gi-vte-2.91.19
-    - git: https://github.com/Grendel-Grendel-Grendel/ostree.git
-      commit: 03f885a01e4a025988770642dd4744ff85c32c29
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -3,13 +3,14 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 resolver: lts-12.13
 
-# Local packages, usually specified by relative directory name
-packages:
-    - '.'
+#Local packages, usually specified by relative directory name
+packages: 
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
     - gi-vte-2.91.19
+    - git: https://github.com/Grendel-Grendel-Grendel/ostree.git
+      commit: 03f885a01e4a025988770642dd4744ff85c32c29
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack-lts-12.yaml
+++ b/stack-lts-12.yaml
@@ -3,8 +3,9 @@
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
 resolver: lts-12.13
 
-#Local packages, usually specified by relative directory name
-packages: 
+# Local packages, usually specified by relative directory name
+packages:
+    - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -76,6 +76,7 @@ library
                      , xml-conduit
                      , xml-html-qq
                      , order-statistic-tree
+                     , containers
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -75,7 +75,6 @@ library
                      , singletons
                      , xml-conduit
                      , xml-html-qq
-                     , order-statistic-tree
                      , containers
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -71,6 +71,7 @@ library
                      , gi-vte >= 2.91.19
                      , haskell-gi-base >= 0.21.2
                      , lens
+                     , mono-traversable
                      , pretty-simple
                      , QuickCheck
                      , singletons

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -138,6 +138,7 @@ test-suite termonad-test
   other-modules:       Test.FocusList
                      , Test.FocusList.Invariants
   build-depends:       base
+                     , genvalidity-containers
                      , genvalidity-hspec
                      , hedgehog
                      , lens

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -57,6 +57,7 @@ library
                      , classy-prelude
                      , colour
                      , constraints
+                     , containers
                      , data-default
                      , directory >= 1.3.1.0
                      , distributive
@@ -75,7 +76,6 @@ library
                      , singletons
                      , xml-conduit
                      , xml-html-qq
-                     , containers
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -75,6 +75,7 @@ library
                      , singletons
                      , xml-conduit
                      , xml-html-qq
+                     , order-statistic-tree
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds

--- a/test/Test/FocusList.hs
+++ b/test/Test/FocusList.hs
@@ -4,35 +4,29 @@ module Test.FocusList where
 
 import Termonad.Prelude
 
-import Test.QuickCheck (Arbitrary, Gen, arbitrary)
+import Data.GenValidity.Sequence ()
+import Test.QuickCheck (Gen)
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.Hedgehog (testProperty)
 import Test.Tasty.Hspec (Spec, testSpec)
-import Test.Validity (GenInvalid, GenUnchecked(genUnchecked, shrinkUnchecked), GenValid(genValid), Validity(validate), check, eqSpec, genValidSpec)
+import Test.Validity (GenInvalid, GenUnchecked, GenValid(genValid), Validity(validate), check, eqSpec, genValidSpec)
 
-import Termonad.FocusList (Focus, FocusList, invariantFL)
+import Termonad.FocusList (Focus, FocusList, genValidFL, invariantFL)
 
 import Test.FocusList.Invariants (testInvariantsInFocusList)
 
-instance Arbitrary a => GenUnchecked (Seq a) where
-  genUnchecked :: Gen (Seq a)
-  genUnchecked = arbitrary
-
-  shrinkUnchecked :: Seq a -> [Seq a]
-  shrinkUnchecked = pure
-
 instance GenUnchecked Focus
 
-instance Arbitrary a => GenUnchecked (FocusList a)
+instance GenUnchecked a => GenUnchecked (FocusList a)
 
 instance Validity (FocusList a) where
   validate fl = check (invariantFL fl) "the FocusList has been constructed correctly"
 
-instance Arbitrary a => GenValid (FocusList a) where
+instance GenValid a => GenValid (FocusList a) where
   genValid :: Gen (FocusList a)
-  genValid = arbitrary
+  genValid = genValidFL genValid
 
-instance Arbitrary a => GenInvalid (FocusList a)
+instance GenInvalid a => GenInvalid (FocusList a)
 
 focusListTestsIO :: IO TestTree
 focusListTestsIO = do

--- a/test/Test/FocusList.hs
+++ b/test/Test/FocusList.hs
@@ -14,11 +14,11 @@ import Termonad.FocusList (Focus, FocusList, invariantFL)
 
 import Test.FocusList.Invariants (testInvariantsInFocusList)
 
-instance Arbitrary a => GenUnchecked (IntMap a) where
-  genUnchecked :: Gen (IntMap a)
+instance Arbitrary a => GenUnchecked (Seq a) where
+  genUnchecked :: Gen (Seq a)
   genUnchecked = arbitrary
 
-  shrinkUnchecked :: IntMap a -> [IntMap a]
+  shrinkUnchecked :: Seq a -> [Seq a]
   shrinkUnchecked = pure
 
 instance GenUnchecked Focus

--- a/test/Test/FocusList/Invariants.hs
+++ b/test/Test/FocusList/Invariants.hs
@@ -103,7 +103,7 @@ generateAction valGen fl = do
       choice generators
 
 performAction :: Eq a => FocusList a -> Action a -> Maybe (FocusList a)
-performAction fl (InsertFL key val) = insertFL key val fl
+performAction fl (InsertFL key val) = Just $ insertFL key val fl
 performAction fl (RemoveFL keyToRemove) = removeFL keyToRemove fl
 performAction fl (DeleteFL valToDelete) = Just $ deleteFL valToDelete fl
 

--- a/test/Test/FocusList/Invariants.hs
+++ b/test/Test/FocusList/Invariants.hs
@@ -3,7 +3,6 @@ module Test.FocusList.Invariants where
 
 import Termonad.Prelude
 
-import Control.Lens ((^.))
 import Hedgehog
   ( Gen
   , Property
@@ -20,7 +19,6 @@ import Hedgehog.Range (constant, linear)
 
 import Termonad.FocusList
   ( FocusList
-  , debugFL
   , deleteFL
   , emptyFL
   , insertFL
@@ -81,7 +79,7 @@ genDeleteFL fl
                 "\nkey: " <>
                 show keyForItemToDelete <>
                 "\nfocus list: " <>
-                debugFL fl
+                show fl
           in error msg
         Just item -> pure $ DeleteFL item
 
@@ -97,7 +95,7 @@ generateAction valGen fl = do
     [] ->
       let msg =
             "No generators available for fl:\n" <>
-            debugFL fl
+            show fl
       in error msg
     _ -> do
       choice generators

--- a/test/Test/FocusList/Invariants.hs
+++ b/test/Test/FocusList/Invariants.hs
@@ -26,7 +26,7 @@ import Termonad.FocusList
   , insertFL
   , invariantFL
   , isEmptyFL
-  , lensFocusListLen
+  , lengthFL
   , lookupFL
   , removeFL
   )
@@ -53,7 +53,7 @@ genInsertFL valGen fl
       val <- valGen
       pure $ InsertFL 0 val
   | otherwise = Just $ do
-      let len = fl ^. lensFocusListLen
+      let len = lengthFL fl
       key <- int $ constant 0 len
       val <- valGen
       pure $ InsertFL key val
@@ -62,7 +62,7 @@ genRemoveFL :: FocusList a -> Maybe (Gen (Action a))
 genRemoveFL fl
   | isEmptyFL fl = Nothing
   | otherwise = Just $ do
-      let len = fl ^. lensFocusListLen
+      let len = lengthFL fl
       keyToRemove <- int $ constant 0 (len - 1)
       pure $ RemoveFL keyToRemove
 
@@ -70,7 +70,7 @@ genDeleteFL :: Show a => FocusList a -> Maybe (Gen (Action a))
 genDeleteFL fl
   | isEmptyFL fl = Nothing
   | otherwise = Just $ do
-      let len = fl ^. lensFocusListLen
+      let len = lengthFL fl
       keyForItemToDelete <- int $ constant 0 (len - 1)
       let maybeItemToDelete = lookupFL keyForItemToDelete fl
       case maybeItemToDelete of


### PR DESCRIPTION
This overhauls `FocusList` to use `Sequence` instead of `Intmap`. After I updated documentation, it passes all tests. Resolves issue #64, excepting that I have not added big O growth rates. according to my innovative benchmarking techinque of "opening as many tabs as possible and watching the results in htop."

Many functions were scrapped because they no longer serve any purpose, along with their documentation. One function which has changed significantly is `insertFL` which no longer has an unsafe counterpart. Instead, it behaves according to how `insertAt` from `Sequence` does. That is, if an index is out of bounds, it will be inserted at the "nearest" available index. Look to the code examples for demonstration. In general, I have made the `FocusList` methods behave like their corresponding `Sequence` methods as with `insertAt`. 

I also did not use lenses where it seemed like ordinary record syntax was shorter and more readable, as I am not terribly familiar with lenses.