### PR TITLE
Fix paste hotkey

### DIFF
--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -341,7 +341,7 @@ setupTermonad tmConfig app win builder = do
     maybeTerm <- getFocusedTermFromState mvarTMState
     maybe (pure ()) terminalPasteClipboard maybeTerm
   actionMapAddAction app pasteAction
-  applicationSetAccelsForAction app "app.paste" ["<Shift><Ctrl>C"]
+  applicationSetAccelsForAction app "app.paste" ["<Shift><Ctrl>V"]
 
   aboutAction <- simpleActionNew "about" Nothing
   void $ onSimpleActionActivate aboutAction (const $ showAboutDialog app)


### PR DESCRIPTION
Paste's hotkey was typo'd/overlapping with copy's use of ctrl-shift-c. I changed it to ctrl-shift-v.