### PR TITLE
Fix problem with NIX_GHC not getting set in the wrapper script

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -93,4 +93,3 @@ let
   };
 
 in import nixpkgsSrc { overlays = [ haskellPackagesOverlay ]; }
-

--- a/.nix-helpers/termonad-with-packages.nix
+++ b/.nix-helpers/termonad-with-packages.nix
@@ -114,18 +114,12 @@ stdenv.mkDerivation {
   name = "termonad-with-packages-${env.version}";
   buildInputs = [ gnome3.adwaita-icon-theme hicolor-icon-theme ];
   nativeBuildInputs = [ wrapGAppsHook ];
-  preFixup = ''
-    gappsWrapperArgs+=(
-      # Thumbnailers (this probably isn't actually needed, but it is a good example of how to use --prefix)
-      --prefix XDG_DATA_DIRS : "${gdk_pixbuf}/share"
-      --prefix XDG_DATA_DIRS : "${librsvg}/share"
-      --prefix XDG_DATA_DIRS : "${shared-mime-info}/share"
-      --set NIX_GHC "${env}/bin/ghc"
-      )
-    '';
   buildCommand = ''
     mkdir -p $out/bin
     ln -sf ${env}/bin/termonad $out/bin/termonad
+    gappsWrapperArgs+=(
+      --set NIX_GHC "${env}/bin/ghc"
+    )
     wrapGAppsHook
   '';
   preferLocalBuild = true;


### PR DESCRIPTION
#91 changed the termonad wrapper script to use `wrapGAppsHook` instead of `makeWrapper`.  I believe this is the correct approach for GTK applications, but I made a mistake and didn't set the `NIX_GHC` environment variable.

I did test #91 on my own system, but I made the mistake of running termonad compiled with #91 from a termonad instance which had `NIX_GHC` set in the environment.  This made it so I didn't realize `NIX_GHC` wasn't getting set correctly.  (Although I really should have noticed it, since I looked at the output wrapper script multiple times...)

This bug was correctly diagnosed by @romanofski and @LSLeary in #92.  This fixes #92.  Sorry for causing this problem and not sufficiently testing.

I'll go ahead and merge this, since I don't want other users to run into this problem, but please feel free to comment if this doesn't actually fix the problem for you.