### PR TITLE
Get Termonad compatible with LTS-13

### DIFF
--- a/.nix-helpers/stack-nix-shell.nix
+++ b/.nix-helpers/stack-nix-shell.nix
@@ -2,10 +2,10 @@
 # This runs stack commands in an environment created with nix.
 
 let
-  # recent version of nixpkgs as of 2018-10-17
+  # recent version of nixpkgs master as of 2018-12-23
   nixpkgsTarball = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/6a23e11e658b7a7a77f1b61d30d64153b46bc852.tar.gz";
-    sha256 = "03n4bacfk1bbx3v0cx8xcgcmz44l0knswzh7hwih9nx0hj3x41yc";
+    url = "https://github.com/NixOS/nixpkgs/archive/c31c0558ddad7161a4025117694197264cda9750.tar.gz";
+    sha256 = "09xl8fshyyddcm5nw5fkl6fbjlh5szjcdm43ii6jsvykdr516ghp";
   };
 
   # Fixes for individual packages.  Currently none needed.
@@ -31,8 +31,8 @@ haskell.lib.buildStackProject {
     gtk3
     zlib
   ];
-  ghc = haskell.compiler.ghc843;
+  ghc = haskell.compiler.ghc863;
   extraArgs = [
-    "--stack-yaml stack-lts-12.yaml"
+    "--stack-yaml stack-lts-13.yaml"
   ];
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,21 @@ matrix:
           - libgmp-dev
           - libvte-2.91-dev
 
+  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.3"
+    addons:
+      apt:
+        sources:
+          - hvr-ghc
+        packages:
+          - alex-3.1.7
+          - cabal-install-2.4
+          - ghc-8.6.3
+          - happy-1.19.5
+          - libgirepository1.0-dev
+          - libgmp-dev
+          - libvte-2.91-dev
+
   # Build with the newest GHC and cabal-install. This is an accepted failure,
   # see below.
   # - env: BUILD=cabal GHCVER=head  CABALVER=head HAPPYVER=1.19.5 ALEXVER=3.1.7
@@ -125,6 +140,15 @@ matrix:
 
   - env: BUILD=stack ARGS="--resolver lts-12"
     compiler: ": #stack 8.4.3"
+    addons:
+      apt:
+        packages:
+          - libgirepository1.0-dev
+          - libgmp-dev
+          - libvte-2.91-dev
+
+  - env: BUILD=stack ARGS="--resolver lts-13"
+    compiler: ": #stack 8.6.3"
     addons:
       apt:
         packages:

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -9,6 +9,8 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
+  - hedgehog-0.6.1
+  - tasty-hedgehog-0.2.0.0
   # These two packages should be added to a later version of LTS-13:
   # https://github.com/commercialhaskell/lts-haskell/issues/196
   - xml-html-qq-0.1.0.1

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,0 +1,44 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-13.0
+
+# Local packages, usually specified by relative directory name
+packages:
+    - '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+  # These two packages should be added to a later version of LTS-13:
+  # https://github.com/commercialhaskell/lts-haskell/issues/196
+  - xml-html-qq-0.1.0.1
+  - heterocephalus-1.0.5.3
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor
+
+nix:
+    packages: []
+    pure: true
+    shell-file: .nix-helpers/stack-nix-shell.nix

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,1 @@
-stack-lts-12.yaml
+stack-lts-13.yaml

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -50,7 +50,7 @@ library
                      , Termonad.Types
                      , Termonad.XML
   other-modules:       Paths_termonad
-  build-depends:       base >= 4.7 && < 5
+  build-depends:       base >= 4.11 && < 5
                      , adjunctions
                      , classy-prelude
                      , colour


### PR DESCRIPTION
This switches Termonad over to use LTS-13 when compiled with `stack`.

This is the continuation of the GHC-8.6 support added by @clinty.