### PR TITLE
Get building with nixpkgs 19.03

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -9,9 +9,9 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # recent version of nixpkgs master as of 2019-01-09
-          url = "https://github.com/NixOS/nixpkgs/archive/beaf69cee298e092698dd2da2e4758b7811859ad.tar.gz";
-          sha256 = "0863a8bgb9z2cbjcwp2xqspsbqcnq035k7rfylicxa75gsj9xgk1";
+          # recent version of nixpkgs master as of 2019-03-02
+          url = "https://github.com/NixOS/nixpkgs/archive/07e2b59812de95deeedde95fb6ba22d581d12fbc.tar.gz";
+          sha256 = "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf";
         }
       else
         nixpkgs;
@@ -51,7 +51,7 @@ let
             self.haskell.lib.overrideCabal;
 
         # https://github.com/NixOS/nixpkgs/pull/53682
-        genvalidity-hspec = dontCheck hsuper.genvalidity-hspec;
+        # genvalidity-hspec = dontCheck hsuper.genvalidity-hspec;
       };
     };
   };

--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -9,7 +9,7 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # recent version of nixpkgs master as of 2019-03-02
+          # Recent version of nixpkgs-19.03 as of 2019-03-02.
           url = "https://github.com/NixOS/nixpkgs/archive/07e2b59812de95deeedde95fb6ba22d581d12fbc.tar.gz";
           sha256 = "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf";
         }

--- a/.nix-helpers/stack-fhs-env.nix
+++ b/.nix-helpers/stack-fhs-env.nix
@@ -12,10 +12,10 @@
 # From here, you can run `stack` normally.
 
 let
-  # recent version of nixpkgs master as of 2018-12-23
+  # Recent version of nixpkgs-19.03 as of 2019-03-02.
   nixpkgsTarball = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/c31c0558ddad7161a4025117694197264cda9750.tar.gz";
-    sha256 = "09xl8fshyyddcm5nw5fkl6fbjlh5szjcdm43ii6jsvykdr516ghp";
+    url = "https://github.com/NixOS/nixpkgs/archive/07e2b59812de95deeedde95fb6ba22d581d12fbc.tar.gz";
+    sha256 = "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf";
   };
 
   # Additional packages or fixes for individual packages.

--- a/.nix-helpers/stack-shell.nix
+++ b/.nix-helpers/stack-shell.nix
@@ -2,7 +2,7 @@
 # This runs stack commands in an environment created with nix.
 
 let
-  # recent version of nixpkgs master as of 2019-03-02
+  # Recent version of nixpkgs-19.03 as of 2019-03-02.
   nixpkgsTarball = builtins.fetchTarball {
     url = "https://github.com/NixOS/nixpkgs/archive/07e2b59812de95deeedde95fb6ba22d581d12fbc.tar.gz";
     sha256 = "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf";

--- a/.nix-helpers/stack-shell.nix
+++ b/.nix-helpers/stack-shell.nix
@@ -2,10 +2,10 @@
 # This runs stack commands in an environment created with nix.
 
 let
-  # recent version of nixpkgs master as of 2018-12-23
+  # recent version of nixpkgs master as of 2019-03-02
   nixpkgsTarball = builtins.fetchTarball {
-    url = "https://github.com/NixOS/nixpkgs/archive/c31c0558ddad7161a4025117694197264cda9750.tar.gz";
-    sha256 = "09xl8fshyyddcm5nw5fkl6fbjlh5szjcdm43ii6jsvykdr516ghp";
+    url = "https://github.com/NixOS/nixpkgs/archive/07e2b59812de95deeedde95fb6ba22d581d12fbc.tar.gz";
+    sha256 = "1yxmv04v2dywk0a5lxvi9a2rrfq29nw8qsm33nc856impgxadpgf";
   };
 
   # Fixes for individual packages.  Currently none needed.

--- a/default.nix
+++ b/default.nix
@@ -17,7 +17,7 @@
 #
 # $ nix-env --file default.nix --install
 
-{ compiler ? null, nixpkgs ? null }:
+{ compiler ? null, nixpkgs ? null }@args:
 
-import .nix-helpers/termonad-with-packages.nix { inherit compiler nixpkgs; }
+import .nix-helpers/termonad-with-packages.nix args
 

--- a/stack-lts-13.yaml
+++ b/stack-lts-13.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-13.3
+resolver: lts-13.9
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,7 +9,6 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - hedgehog-0.6.1
   - tasty-hedgehog-0.2.0.0
 
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
Update to use the latest version of nixpkgs.