### PR TITLE
Fix foreground and background colors

### DIFF
--- a/example-config/ExampleColourExtension.hs
+++ b/example-config/ExampleColourExtension.hs
@@ -45,7 +45,7 @@ myColourConfig =
     -- cursor.
     { cursorBgColour = Set (sRGB24 120 80 110) -- purple
     -- Set the default foreground colour of text of the terminal.
-    , foregroundColour = sRGB24 220 180 210 -- light pink
+    , foregroundColour = Set (sRGB24 220 180 210) -- light pink
     -- Set the extended palette that has 8 colours standard colors and then 8
     -- light colors.
     , palette = ExtendedPalette myStandardColours myLightColours

--- a/example-config/ExampleSolarizedColourExtension.hs
+++ b/example-config/ExampleSolarizedColourExtension.hs
@@ -39,7 +39,7 @@ solarizedDark :: ColourConfig (Colour Double)
 solarizedDark =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
-    { foregroundColour = sRGB24 131 148 150 -- base0
+    { foregroundColour = Set (sRGB24 131 148 150) -- base0
     -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
     , palette = ExtendedPalette solarizedDark1 solarizedDark2
     }
@@ -73,7 +73,7 @@ solarizedLight :: ColourConfig (Colour Double)
 solarizedLight =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
-    { foregroundColour = sRGB24 101 123 131 -- base00
+    { foregroundColour = Set (sRGB24 101 123 131) -- base00
     -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
     , palette = ExtendedPalette solarizedLight1 solarizedLight2
     }

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -72,8 +72,7 @@ import GI.Pango
   , fontDescriptionSetAbsoluteSize
   )
 import GI.Vte
-  ( Terminal
-  , terminalCopyClipboard
+  ( terminalCopyClipboard
   , terminalPasteClipboard
   , terminalSetFont
   )
@@ -180,15 +179,17 @@ adjustFontDescSize f fontDesc = do
   let currFontSz =
         if currAbsolute
           then FontSizeUnits $ fromIntegral currSize / fromIntegral SCALE
-          else FontSizePoints $ round (fromIntegral currSize / fromIntegral SCALE)
+          else
+            let fontRatio :: Double = fromIntegral currSize / fromIntegral SCALE
+            in FontSizePoints $ round fontRatio
   let newFontSz = f currFontSz
   setFontDescSize fontDesc newFontSz
 
 modifyFontSizeForAllTerms :: (FontSize -> FontSize) -> TMState -> IO ()
-modifyFontSizeForAllTerms modFontSize mvarTMState = do
+modifyFontSizeForAllTerms modFontSizeFunc mvarTMState = do
   tmState <- readMVar mvarTMState
   let fontDesc = tmState ^. lensTMStateFontDesc
-  adjustFontDescSize modFontSize fontDesc
+  adjustFontDescSize modFontSizeFunc fontDesc
   let terms =
         tmState ^..
           lensTMStateNotebook .

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -56,8 +56,6 @@ module Termonad.Config
   , CursorBlinkMode(..)
   ) where
 
-import Termonad.Prelude hiding ((\\), index)
-
 import GI.Vte (CursorBlinkMode(..))
 
 import Termonad.Types


### PR DESCRIPTION
This PR fixes the bug in #29 with not being able to set the background color for a terminal if the palette was set.

In #110, @dakotaclemenceplaza figured out that this was caused by not setting any value for the alpha channel of an RGBA color.

This PR uses the fix from #110 and simplifies some of the logic for setting colors.

Fixes #29