### PR TITLE
Change Colour to AlphaColour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,14 +105,15 @@ matrix:
 
   # The Stack builds. We can pass in arbitrary Stack arguments via the ARGS
   # variable, such as using --stack-yaml to point to a different file.
-  - env: BUILD=stack ARGS=""
-    compiler: ": #stack default"
-    addons:
-      apt:
-        packages:
-          - libgirepository1.0-dev
-          - libgmp-dev
-          - libvte-2.91-dev
+  # This runs over the 50 minute Travis CI time limit, so it is disabled.
+  # - env: BUILD=stack ARGS=""
+  #   compiler: ": #stack default"
+  #   addons:
+  #     apt:
+  #       packages:
+  #         - libgirepository1.0-dev
+  #         - libgmp-dev
+  #         - libvte-2.91-dev
 
   #- env: BUILD=stack ARGS="--resolver lts-2"
   #  compiler: ": #stack 7.8.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -67,8 +67,8 @@ matrix:
   # - env: BUILD=cabal GHCVER=8.2.2 CABALVER=2.0 HAPPYVER=1.19.5 ALEXVER=3.1.7
   #   compiler: ": #GHC 8.2.2"
   #   addons: {apt: {packages: [cabal-install-2.0,ghc-8.2.2,happy-1.19.5,alex-3.1.7], sources: [hvr-ghc]}}
-  - env: BUILD=cabal GHCVER=8.4.3 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.4.3"
+  - env: BUILD=cabal GHCVER=8.4.4 CABALVER=2.2 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.4.4"
     addons:
       apt:
         sources:
@@ -76,14 +76,14 @@ matrix:
         packages:
           - alex-3.1.7
           - cabal-install-2.2
-          - ghc-8.4.3
+          - ghc-8.4.4
           - happy-1.19.5
           - libgirepository1.0-dev
           - libgmp-dev
           - libvte-2.91-dev
 
-  - env: BUILD=cabal GHCVER=8.6.3 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
-    compiler: ": #GHC 8.6.3"
+  - env: BUILD=cabal GHCVER=8.6.5 CABALVER=2.4 HAPPYVER=1.19.5 ALEXVER=3.1.7
+    compiler: ": #GHC 8.6.5"
     addons:
       apt:
         sources:
@@ -91,7 +91,7 @@ matrix:
         packages:
           - alex-3.1.7
           - cabal-install-2.4
-          - ghc-8.6.3
+          - ghc-8.6.5
           - happy-1.19.5
           - libgirepository1.0-dev
           - libgmp-dev
@@ -140,7 +140,7 @@ matrix:
   #   addons: {apt: {packages: [libgmp-dev]}}
 
   - env: BUILD=stack ARGS="--resolver lts-12"
-    compiler: ": #stack 8.4.3"
+    compiler: ": #stack 8.4.4"
     addons:
       apt:
         packages:
@@ -149,7 +149,7 @@ matrix:
           - libvte-2.91-dev
 
   - env: BUILD=stack ARGS="--resolver lts-13"
-    compiler: ": #stack 8.6.3"
+    compiler: ": #stack 8.6.5"
     addons:
       apt:
         packages:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 1.3.0.0
+
+* Change all uses of
+  [`Colour`](http://hackage.haskell.org/package/colour-2.3.5/docs/Data-Colour.html#t:Colour)
+  to
+  [`AlphaColour`](http://hackage.haskell.org/package/colour-2.3.5/docs/Data-Colour.html#t:AlphaColour)
+  in `Termonad.Config.Colour`.  Users should now use `AlphaColour` instead of
+  `Colour`.  Also, all uses of `sRGB24` should be replaced with `createColour`.
+  This change is mechanical and should not affect how Termonad works at all.
+  Thanks to @jecaro and @amir! [#116](https://github.com/cdepillabout/termonad/pull/116)
+
 ## 1.2.0.0
 
 * Got the code for setting the backgroud color of the terminal actually

--- a/README.md
+++ b/README.md
@@ -243,7 +243,6 @@ module.
 
 module Main where
 
-import Data.Colour.SRGB (Colour, sRGB24)
 import Termonad.App (defaultMain)
 import Termonad.Config
   ( FontConfig, FontSize(FontSizePoints), Option(Set)
@@ -251,23 +250,23 @@ import Termonad.Config
   , defaultTMConfig, fontConfig, fontFamily, fontSize, options, showScrollbar
   )
 import Termonad.Config.Colour
-  (ColourConfig, addColourExtension, createColourExtension, cursorBgColour
-  , defaultColourConfig
+  ( AlphaColour, ColourConfig, addColourExtension, createColour
+  , createColourExtension, cursorBgColour, defaultColourConfig
   )
 
 -- | This sets the color of the cursor in the terminal.
 --
 -- This uses the "Data.Colour" module to define a dark-red color.
 -- There are many default colors defined in "Data.Colour.Names".
-cursBgColor :: Colour Double
-cursBgColor = sRGB24 204 0 0
+cursBgColour :: AlphaColour Double
+cursBgColour = createColour 204 0 0
 
 -- | This sets the colors used for the terminal.  We only specify the background
 -- color of the cursor.
-colConf :: ColourConfig (Colour Double)
+colConf :: ColourConfig (AlphaColour Double)
 colConf =
   defaultColourConfig
-    { cursorBgColour = Set cursBgColor
+    { cursorBgColour = Set cursBgColour
     }
 
 -- | This defines the font for the terminal.

--- a/example-config/ExampleColourExtension.hs
+++ b/example-config/ExampleColourExtension.hs
@@ -4,7 +4,6 @@
 
 module Main where
 
-import Data.Colour.SRGB (Colour, sRGB24)
 import Data.Singletons (sing)
 import Termonad
   ( CursorBlinkMode(CursorBlinkModeOff), Option(Set)
@@ -13,9 +12,9 @@ import Termonad
   , start
   )
 import Termonad.Config.Colour
-  ( Colour, ColourConfig, Palette(ExtendedPalette), addColourExtension
-  , createColourExtension, cursorBgColour, defaultColourConfig, foregroundColour
-  , palette, sRGB24
+  ( AlphaColour, ColourConfig, Palette(ExtendedPalette), addColourExtension
+  , createColour, createColourExtension, cursorBgColour, defaultColourConfig
+  , foregroundColour, palette
   )
 import Termonad.Config.Vec
   ( N4, N8, Sing, Vec((:*), EmptyVec), fin_, setAtVec, unsafeFromListVec_
@@ -38,14 +37,14 @@ myTMConfig =
     }
 
 -- This is our 'ColourConfig'.  It holds all of our colour-related settings.
-myColourConfig :: ColourConfig (Colour Double)
+myColourConfig :: ColourConfig (AlphaColour Double)
 myColourConfig =
   defaultColourConfig
     -- Set the cursor background colour.  This is the normal colour of the
     -- cursor.
-    { cursorBgColour = Set (sRGB24 120 80 110) -- purple
+    { cursorBgColour = Set (createColour 120 80 110) -- purple
     -- Set the default foreground colour of text of the terminal.
-    , foregroundColour = Set (sRGB24 220 180 210) -- light pink
+    , foregroundColour = Set (createColour 220 180 210) -- light pink
     -- Set the extended palette that has 8 colours standard colors and then 8
     -- light colors.
     , palette = ExtendedPalette myStandardColours myLightColours
@@ -53,40 +52,40 @@ myColourConfig =
   where
     -- This is a an example of creating a length-indexed linked-list of colours,
     -- using 'Vec' constructors.
-    myStandardColours :: Vec N8 (Colour Double)
+    myStandardColours :: Vec N8 (AlphaColour Double)
     myStandardColours =
-         sRGB24  40  30  20 -- dark brown (used as background colour)
-      :* sRGB24 180  30  20 -- red
-      :* sRGB24  40 160  20 -- green
-      :* sRGB24 180 160  20 -- dark yellow
-      :* sRGB24  40  30 120 -- dark purple
-      :* sRGB24 180  30 120 -- bright pink
-      :* sRGB24  40 160 120 -- teal
-      :* sRGB24 180 160 120 -- light brown
+         createColour  40  30  20 -- dark brown (used as background colour)
+      :* createColour 180  30  20 -- red
+      :* createColour  40 160  20 -- green
+      :* createColour 180 160  20 -- dark yellow
+      :* createColour  40  30 120 -- dark purple
+      :* createColour 180  30 120 -- bright pink
+      :* createColour  40 160 120 -- teal
+      :* createColour 180 160 120 -- light brown
       :* EmptyVec
 
     -- This is an example of creating a length-indexed linked-list of colours,
     -- using the 'unsafeFromListVec_' function.  'unsafeFromListVec_' is okay to
     -- use as long as you're absolutely sure you have 8 elements.
-    myLightColours :: Vec N8 (Colour Double)
+    myLightColours :: Vec N8 (AlphaColour Double)
     myLightColours =
       unsafeFromListVec_
-        [ sRGB24  70  60  50 -- brown
-        , sRGB24 220  30  20 -- light red
-        , sRGB24  40 210  20 -- light green
-        , sRGB24 220 200  20 -- yellow
-        , sRGB24  40  30 180 -- purple
-        , sRGB24 140  30 80  -- dark pink
-        , sRGB24  50 200 160 -- light teal
-        , sRGB24 220 200 150 -- light brown
+        [ createColour  70  60  50 -- brown
+        , createColour 220  30  20 -- light red
+        , createColour  40 210  20 -- light green
+        , createColour 220 200  20 -- yellow
+        , createColour  40  30 180 -- purple
+        , createColour 140  30 80  -- dark pink
+        , createColour  50 200 160 -- light teal
+        , createColour 220 200 150 -- light brown
         ]
 
     -- This is an example of updating just a single value in a 'Colour' 'Vec'.
     -- Here we are updating the 5th 'Colour' (which is at index 4).
-    updateSingleColor :: Vec N8 (Colour Double)
-    updateSingleColor =
+    _updateSingleColor :: Vec N8 (AlphaColour Double)
+    _updateSingleColor =
       let fin4 = fin_ (sing :: Sing N4)
-      in setAtVec fin4 (sRGB24 40 30 150) myStandardColours
+      in setAtVec fin4 (createColour 40 30 150) myStandardColours
 
 main :: IO ()
 main = do

--- a/example-config/ExampleSolarizedColourExtension.hs
+++ b/example-config/ExampleSolarizedColourExtension.hs
@@ -38,7 +38,7 @@ solarizedDark =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
     { foregroundColour = Set (createColour 131 148 150) -- base0
-    -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
+    -- Set the extended palette that has 2 Vecs of 8 Solarized palette colours
     , palette = ExtendedPalette solarizedDark1 solarizedDark2
     }
   where
@@ -72,7 +72,7 @@ solarizedLight =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
     { foregroundColour = Set (createColour 101 123 131) -- base00
-    -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
+    -- Set the extended palette that has 2 Vecs of 8 Solarized palette colours
     , palette = ExtendedPalette solarizedLight1 solarizedLight2
     }
   where

--- a/example-config/ExampleSolarizedColourExtension.hs
+++ b/example-config/ExampleSolarizedColourExtension.hs
@@ -1,7 +1,6 @@
 -- | This is an example Termonad configuration that shows how to use the
 -- Solarized colour scheme https://ethanschoonover.com/solarized/
 
-
 module Main where
 
 import Termonad
@@ -11,12 +10,11 @@ import Termonad
   , start
   )
 import Termonad.Config.Colour
-  ( Colour, ColourConfig, Palette(ExtendedPalette), addColourExtension
-  , createColourExtension, cursorBgColour, defaultColourConfig, foregroundColour
-  , palette, sRGB24
+  ( AlphaColour, ColourConfig, Palette(ExtendedPalette), addColourExtension
+  , createColour, createColourExtension, defaultColourConfig
+  , foregroundColour, palette
   )
-import Termonad.Config.Vec (Vec((:*), EmptyVec), N8, unsafeFromListVec_)
-import Data.Colour.SRGB (Colour, sRGB24)
+import Termonad.Config.Vec (Vec((:*), EmptyVec), N8)
 
 -- This is our main 'TMConfig'.  It holds all of the non-colour settings
 -- for Termonad.
@@ -35,71 +33,71 @@ myTMConfig =
     }
 
 -- This is our Solarized dark 'ColourConfig'.  It holds all of our dark-related settings.
-solarizedDark :: ColourConfig (Colour Double)
+solarizedDark :: ColourConfig (AlphaColour Double)
 solarizedDark =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
-    { foregroundColour = Set (sRGB24 131 148 150) -- base0
+    { foregroundColour = Set (createColour 131 148 150) -- base0
     -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
     , palette = ExtendedPalette solarizedDark1 solarizedDark2
     }
   where
-    solarizedDark1 :: Vec N8 (Colour Double)
+    solarizedDark1 :: Vec N8 (AlphaColour Double)
     solarizedDark1 =
-         sRGB24   0  43  54 -- base03, background
-      :* sRGB24 220  50  47 -- red
-      :* sRGB24 133 153   0 -- green
-      :* sRGB24 181 137   0 -- yellow
-      :* sRGB24  38 139 210 -- blue
-      :* sRGB24 211  54 130 -- magenta
-      :* sRGB24  42 161 152 -- cyan
-      :* sRGB24 238 232 213 -- base2
+         createColour   0  43  54 -- base03, background
+      :* createColour 220  50  47 -- red
+      :* createColour 133 153   0 -- green
+      :* createColour 181 137   0 -- yellow
+      :* createColour  38 139 210 -- blue
+      :* createColour 211  54 130 -- magenta
+      :* createColour  42 161 152 -- cyan
+      :* createColour 238 232 213 -- base2
       :* EmptyVec
 
-    solarizedDark2 :: Vec N8 (Colour Double)
+    solarizedDark2 :: Vec N8 (AlphaColour Double)
     solarizedDark2 =
-         sRGB24   7  54  66 -- base02, background highlights
-      :* sRGB24 203  75  22 -- orange
-      :* sRGB24  88 110 117 -- base01, comments / secondary text
-      :* sRGB24 131 148 150 -- base0, body text / default code / primary content
-      :* sRGB24 147 161 161 -- base1, optional emphasised content
-      :* sRGB24 108 113 196 -- violet
-      :* sRGB24 101 123 131 -- base00
-      :* sRGB24 253 246 227 -- base3
+         createColour   7  54  66 -- base02, background highlights
+      :* createColour 203  75  22 -- orange
+      :* createColour  88 110 117 -- base01, comments / secondary text
+      :* createColour 131 148 150 -- base0, body text / default code / primary content
+      :* createColour 147 161 161 -- base1, optional emphasised content
+      :* createColour 108 113 196 -- violet
+      :* createColour 101 123 131 -- base00
+      :* createColour 253 246 227 -- base3
       :* EmptyVec
 
 -- This is our Solarized light 'ColourConfig'.  It holds all of our light-related settings.
-solarizedLight :: ColourConfig (Colour Double)
+solarizedLight :: ColourConfig (AlphaColour Double)
 solarizedLight =
   defaultColourConfig
     -- Set the default foreground colour of text of the terminal.
-    { foregroundColour = Set (sRGB24 101 123 131) -- base00
+    { foregroundColour = Set (createColour 101 123 131) -- base00
     -- Set the extended palette that has 2 Vecs of 8 Solarized pallette colours
     , palette = ExtendedPalette solarizedLight1 solarizedLight2
     }
   where
-    solarizedLight1 :: Vec N8 (Colour Double)
+    solarizedLight1 :: Vec N8 (AlphaColour Double)
     solarizedLight1 =
-         sRGB24 238 232 213 -- base2, background highlights
-      :* sRGB24 220  50  47 -- red
-      :* sRGB24 133 153   0 -- green
-      :* sRGB24 181 137   0 -- yellow
-      :* sRGB24  38 139 210 -- blue
-      :* sRGB24 211  54 130 -- magenta
-      :* sRGB24  42 161 152 -- cyan
-      :* sRGB24   7  54  66 -- base02
+         createColour 238 232 213 -- base2, background highlights
+      :* createColour 220  50  47 -- red
+      :* createColour 133 153   0 -- green
+      :* createColour 181 137   0 -- yellow
+      :* createColour  38 139 210 -- blue
+      :* createColour 211  54 130 -- magenta
+      :* createColour  42 161 152 -- cyan
+      :* createColour   7  54  66 -- base02
       :* EmptyVec
 
-    solarizedLight2 :: Vec N8 (Colour Double)
+    solarizedLight2 :: Vec N8 (AlphaColour Double)
     solarizedLight2 =
-         sRGB24 253 246 227 -- base3, background
-      :* sRGB24 203  75  22 -- orange
-      :* sRGB24 147 161 161 -- base1, comments / secondary text
-      :* sRGB24 101 123 131 -- base00, body text / default code / primary content
-      :* sRGB24  88 110 117 -- base01, optional emphasised content
-      :* sRGB24 108 113 196 -- violet
-      :* sRGB24 131 148 150 -- base0
-      :* sRGB24   0  43  54 -- base03
+         createColour 253 246 227 -- base3, background
+      :* createColour 203  75  22 -- orange
+      :* createColour 147 161 161 -- base1, comments / secondary text
+      :* createColour 101 123 131 -- base00, body text / default code / primary content
+      :* createColour  88 110 117 -- base01, optional emphasised content
+      :* createColour 108 113 196 -- violet
+      :* createColour 131 148 150 -- base0
+      :* createColour   0  43  54 -- base03
       :* EmptyVec
 
 main :: IO ()

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -161,14 +161,14 @@ coloursFromBits scale offset = genVec_ createElem
 -- | A 'Vec' of standard colors.  Default value for 'BasicPalette'.
 --
 -- >>> showColourVec defaultStandardColours
--- ["#000000","#c00000","#00c000","#c0c000","#0000c0","#c000c0","#00c0c0","#c0c0c0"]
+-- ["#000000ff","#c00000ff","#00c000ff","#c0c000ff","#0000c0ff","#c000c0ff","#00c0c0ff","#c0c0c0ff"]
 defaultStandardColours :: (Ord b, Floating b) => Vec N8 (AlphaColour b)
 defaultStandardColours = coloursFromBits 192 0
 
 -- | A 'Vec' of extended (light) colors.  Default value for 'ExtendedPalette'.
 --
 -- >>> showColourVec defaultLightColours
--- ["#3f3f3f","#ff3f3f","#3fff3f","#ffff3f","#3f3fff","#ff3fff","#3fffff","#ffffff"]
+-- ["#3f3f3fff","#ff3f3fff","#3fff3fff","#ffff3fff","#3f3fffff","#ff3fffff","#3fffffff","#ffffffff"]
 defaultLightColours :: (Ord b, Floating b) => Vec N8 (AlphaColour b)
 defaultLightColours = coloursFromBits 192 63
 
@@ -230,47 +230,47 @@ cube d (i :* j :* k :* EmptyVec) =
 -- | A matrix of a 6 x 6 x 6 color cube. Default value for 'ColourCubePalette'.
 --
 -- >>> putStrLn $ pack $ showColourCube defaultColourCube
--- [ [ #000000, #00005f, #000087, #0000af, #0000d7, #0000ff
---   , #005f00, #005f5f, #005f87, #005faf, #005fd7, #005fff
---   , #008700, #00875f, #008787, #0087af, #0087d7, #0087ff
---   , #00af00, #00af5f, #00af87, #00afaf, #00afd7, #00afff
---   , #00d700, #00d75f, #00d787, #00d7af, #00d7d7, #00d7ff
---   , #00ff00, #00ff5f, #00ff87, #00ffaf, #00ffd7, #00ffff
+-- [ [ #000000ff, #00005fff, #000087ff, #0000afff, #0000d7ff, #0000ffff
+--   , #005f00ff, #005f5fff, #005f87ff, #005fafff, #005fd7ff, #005fffff
+--   , #008700ff, #00875fff, #008787ff, #0087afff, #0087d7ff, #0087ffff
+--   , #00af00ff, #00af5fff, #00af87ff, #00afafff, #00afd7ff, #00afffff
+--   , #00d700ff, #00d75fff, #00d787ff, #00d7afff, #00d7d7ff, #00d7ffff
+--   , #00ff00ff, #00ff5fff, #00ff87ff, #00ffafff, #00ffd7ff, #00ffffff
 --   ]
--- , [ #5f0000, #5f005f, #5f0087, #5f00af, #5f00d7, #5f00ff
---   , #5f5f00, #5f5f5f, #5f5f87, #5f5faf, #5f5fd7, #5f5fff
---   , #5f8700, #5f875f, #5f8787, #5f87af, #5f87d7, #5f87ff
---   , #5faf00, #5faf5f, #5faf87, #5fafaf, #5fafd7, #5fafff
---   , #5fd700, #5fd75f, #5fd787, #5fd7af, #5fd7d7, #5fd7ff
---   , #5fff00, #5fff5f, #5fff87, #5fffaf, #5fffd7, #5fffff
+-- , [ #5f0000ff, #5f005fff, #5f0087ff, #5f00afff, #5f00d7ff, #5f00ffff
+--   , #5f5f00ff, #5f5f5fff, #5f5f87ff, #5f5fafff, #5f5fd7ff, #5f5fffff
+--   , #5f8700ff, #5f875fff, #5f8787ff, #5f87afff, #5f87d7ff, #5f87ffff
+--   , #5faf00ff, #5faf5fff, #5faf87ff, #5fafafff, #5fafd7ff, #5fafffff
+--   , #5fd700ff, #5fd75fff, #5fd787ff, #5fd7afff, #5fd7d7ff, #5fd7ffff
+--   , #5fff00ff, #5fff5fff, #5fff87ff, #5fffafff, #5fffd7ff, #5fffffff
 --   ]
--- , [ #870000, #87005f, #870087, #8700af, #8700d7, #8700ff
---   , #875f00, #875f5f, #875f87, #875faf, #875fd7, #875fff
---   , #878700, #87875f, #878787, #8787af, #8787d7, #8787ff
---   , #87af00, #87af5f, #87af87, #87afaf, #87afd7, #87afff
---   , #87d700, #87d75f, #87d787, #87d7af, #87d7d7, #87d7ff
---   , #87ff00, #87ff5f, #87ff87, #87ffaf, #87ffd7, #87ffff
+-- , [ #870000ff, #87005fff, #870087ff, #8700afff, #8700d7ff, #8700ffff
+--   , #875f00ff, #875f5fff, #875f87ff, #875fafff, #875fd7ff, #875fffff
+--   , #878700ff, #87875fff, #878787ff, #8787afff, #8787d7ff, #8787ffff
+--   , #87af00ff, #87af5fff, #87af87ff, #87afafff, #87afd7ff, #87afffff
+--   , #87d700ff, #87d75fff, #87d787ff, #87d7afff, #87d7d7ff, #87d7ffff
+--   , #87ff00ff, #87ff5fff, #87ff87ff, #87ffafff, #87ffd7ff, #87ffffff
 --   ]
--- , [ #af0000, #af005f, #af0087, #af00af, #af00d7, #af00ff
---   , #af5f00, #af5f5f, #af5f87, #af5faf, #af5fd7, #af5fff
---   , #af8700, #af875f, #af8787, #af87af, #af87d7, #af87ff
---   , #afaf00, #afaf5f, #afaf87, #afafaf, #afafd7, #afafff
---   , #afd700, #afd75f, #afd787, #afd7af, #afd7d7, #afd7ff
---   , #afff00, #afff5f, #afff87, #afffaf, #afffd7, #afffff
+-- , [ #af0000ff, #af005fff, #af0087ff, #af00afff, #af00d7ff, #af00ffff
+--   , #af5f00ff, #af5f5fff, #af5f87ff, #af5fafff, #af5fd7ff, #af5fffff
+--   , #af8700ff, #af875fff, #af8787ff, #af87afff, #af87d7ff, #af87ffff
+--   , #afaf00ff, #afaf5fff, #afaf87ff, #afafafff, #afafd7ff, #afafffff
+--   , #afd700ff, #afd75fff, #afd787ff, #afd7afff, #afd7d7ff, #afd7ffff
+--   , #afff00ff, #afff5fff, #afff87ff, #afffafff, #afffd7ff, #afffffff
 --   ]
--- , [ #d70000, #d7005f, #d70087, #d700af, #d700d7, #d700ff
---   , #d75f00, #d75f5f, #d75f87, #d75faf, #d75fd7, #d75fff
---   , #d78700, #d7875f, #d78787, #d787af, #d787d7, #d787ff
---   , #d7af00, #d7af5f, #d7af87, #d7afaf, #d7afd7, #d7afff
---   , #d7d700, #d7d75f, #d7d787, #d7d7af, #d7d7d7, #d7d7ff
---   , #d7ff00, #d7ff5f, #d7ff87, #d7ffaf, #d7ffd7, #d7ffff
+-- , [ #d70000ff, #d7005fff, #d70087ff, #d700afff, #d700d7ff, #d700ffff
+--   , #d75f00ff, #d75f5fff, #d75f87ff, #d75fafff, #d75fd7ff, #d75fffff
+--   , #d78700ff, #d7875fff, #d78787ff, #d787afff, #d787d7ff, #d787ffff
+--   , #d7af00ff, #d7af5fff, #d7af87ff, #d7afafff, #d7afd7ff, #d7afffff
+--   , #d7d700ff, #d7d75fff, #d7d787ff, #d7d7afff, #d7d7d7ff, #d7d7ffff
+--   , #d7ff00ff, #d7ff5fff, #d7ff87ff, #d7ffafff, #d7ffd7ff, #d7ffffff
 --   ]
--- , [ #ff0000, #ff005f, #ff0087, #ff00af, #ff00d7, #ff00ff
---   , #ff5f00, #ff5f5f, #ff5f87, #ff5faf, #ff5fd7, #ff5fff
---   , #ff8700, #ff875f, #ff8787, #ff87af, #ff87d7, #ff87ff
---   , #ffaf00, #ffaf5f, #ffaf87, #ffafaf, #ffafd7, #ffafff
---   , #ffd700, #ffd75f, #ffd787, #ffd7af, #ffd7d7, #ffd7ff
---   , #ffff00, #ffff5f, #ffff87, #ffffaf, #ffffd7, #ffffff
+-- , [ #ff0000ff, #ff005fff, #ff0087ff, #ff00afff, #ff00d7ff, #ff00ffff
+--   , #ff5f00ff, #ff5f5fff, #ff5f87ff, #ff5fafff, #ff5fd7ff, #ff5fffff
+--   , #ff8700ff, #ff875fff, #ff8787ff, #ff87afff, #ff87d7ff, #ff87ffff
+--   , #ffaf00ff, #ffaf5fff, #ffaf87ff, #ffafafff, #ffafd7ff, #ffafffff
+--   , #ffd700ff, #ffd75fff, #ffd787ff, #ffd7afff, #ffd7d7ff, #ffd7ffff
+--   , #ffff00ff, #ffff5fff, #ffff87ff, #ffffafff, #ffffd7ff, #ffffffff
 --   ]
 -- ]
 defaultColourCube :: (Ord b, Floating b) => Matrix '[N6, N6, N6] (AlphaColour b)
@@ -344,7 +344,7 @@ showColourCube matrix =
 -- | A 'Vec' of a grey scale.  Default value for 'FullPalette'.
 --
 -- >>> showColourVec defaultGreyscale
--- ["#080808","#121212","#1c1c1c","#262626","#303030","#3a3a3a","#444444","#4e4e4e","#585858","#626262","#6c6c6c","#767676","#808080","#8a8a8a","#949494","#9e9e9e","#a8a8a8","#b2b2b2","#bcbcbc","#c6c6c6","#d0d0d0","#dadada","#e4e4e4","#eeeeee"]
+-- ["#080808ff","#121212ff","#1c1c1cff","#262626ff","#303030ff","#3a3a3aff","#444444ff","#4e4e4eff","#585858ff","#626262ff","#6c6c6cff","#767676ff","#808080ff","#8a8a8aff","#949494ff","#9e9e9eff","#a8a8a8ff","#b2b2b2ff","#bcbcbcff","#c6c6c6ff","#d0d0d0ff","#dadadaff","#e4e4e4ff","#eeeeeeff"]
 defaultGreyscale :: (Ord b, Floating b) => Vec N24 (AlphaColour b)
 defaultGreyscale = genVec_ $ \n ->
   let l = 8 + 10 * fromIntegral (toIntFin n)

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             1.2.0.0
+version:             1.3.0.0
 synopsis:            Terminal emulator configurable in Haskell
 description:         Please see <https://github.com/cdepillabout/termonad#readme README.md>.
 homepage:            https://github.com/cdepillabout/termonad

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -180,6 +180,7 @@ executable termonad-readme
                      , colour
   ghc-options:         -pgmL markdown-unlit
   default-language:    Haskell2010
+  ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N
 
   if flag(buildexamples)
     buildable:         True
@@ -193,6 +194,7 @@ executable termonad-example-colour-extension
                      , colour
                      , singletons
   default-language:    Haskell2010
+  ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N
 
   if flag(buildexamples)
     buildable:         True
@@ -206,6 +208,7 @@ executable termonad-example-colour-extension-solarized
                      , colour
                      , singletons
   default-language:    Haskell2010
+  ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -threaded -rtsopts -with-rtsopts=-N
 
   if flag(buildexamples)
     buildable:         True


### PR DESCRIPTION
This PR fix #112

It seems that there is no direct way to get the RGB components back from an AlphaColour. So I needed to work around, which feels kind of hacky. See the comments for more informations.

Also the functions used to convert RGB components to word8 are not exposed from the Colour library. So I had to copy pieces of code from the Internal module to make sure it's going to behave in a consistent way.