### PR TITLE
outsource nix arguments to .nix-helpers

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -17,11 +17,7 @@
 #
 # $ nix-env --file default.nix --install
 
-{ nixpkgs ? null
-, additionalOverlays ? []
-, compiler ? null
-, buildExamples ? false
-}@args:
+{ ... }@args:
 
 import .nix-helpers/termonad-with-packages.nix args
 

--- a/shell.nix
+++ b/shell.nix
@@ -24,9 +24,10 @@
 # will also index the Termonad libraries, however this will mean the environment
 # will need to be rebuilt every time the termonad source changes.
 
-{ compiler ? null, indexTermonad ? false, nixpkgs ? null, additionalOverlays ? [] }:
+{ indexTermonad ? false, ... }@origArgs:
 
-with (import .nix-helpers/nixpkgs.nix { inherit compiler nixpkgs additionalOverlays; });
+let args = builtins.removeAttrs origArgs [ "indexTermonad" ];
+in with (import .nix-helpers/nixpkgs.nix args);
 
 let
   # A Haskell package set for a version of GHC that is known working.


### PR DESCRIPTION
I was trying to add some extraHaskellPackages to my termonad config. I find `default.nix` doesn't accept the same set of arguments with `.nix-helpers/termonad-with-packages.nix`.

I think we need to outsource `shell.nix` and `default.nix` arguments to `.nix-helpers/termonad-with-packages.nix`. It will be easy to keep them up to date this way.