### PR TITLE
Update Ubuntu / Debian dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ $ stack install
 First, you must install the required GTK system libraries:
 
 ```sh
-$ apt-get install gobject-introspection libgirepository1.0-dev libgtk-3-dev libvte-2.91-dev
+$ apt-get install gobject-introspection libgirepository1.0-dev libgtk-3-dev libvte-2.91-dev libpcre2-dev
 ```
 
 In order to install Termonad, clone this repository and run `stack install`.


### PR DESCRIPTION
On Ubuntu 18.04, trying to install the dependency list and then running `stack install` resulted in
`setup: The pkg-config package 'libpcre2-8' is required but it could not be found.`

After installing `libpcre2-dev` as well I was able to install using stack and run termonad.