### PR TITLE
Add a context menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+
+## next
+
+* Add a right-click menu for the terminal.  It currently allows copy and
+  paste.  [#136](https://github.com/cdepillabout/termonad/pull/136)  Thanks
+  @jecaro!
+
 ## 2.1.0.0
 
 * Add a menu option to set preferences for a running Termonad session.  The preferences you have set are lost when you end the Termonad session. [#130](https://github.com/cdepillabout/termonad/pull/130)  Thanks @jecaro!


### PR DESCRIPTION
This PR adds a very simple context menu to Termonad #12.

For now I've put only copy/paste items. But adding existing actions to the menu is pretty straight forward. 

I've worked a bit on adding an action to open an url in a navigator. It's not as easy at it seems for two reasons:
- Some annotations in Vte functions are missing but I sent a PR to fix it haskell-gi/haskell-gi#265
- It requieres to cast `EventButton` to `Event` to be able to call `terminalMatchCheckEvent` and it's not currently supported by haskell-gi. This issue haskell-gi/haskell-gi#109 is exactly the same as the one I run on. There is a workaround decribed in the issue thought.