### PR TITLE
Get rid of the one-pixel border around the GtkNotebook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 
 ## next
 
+* Remove the one-pixel white border around the `GtkNotebook` (the GTK widget thing
+  that contains the tabs). [#138]
 * Add a right-click menu for the terminal.  It currently allows copy and
   paste.  [#136](https://github.com/cdepillabout/termonad/pull/136)  Thanks
   @jecaro!

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -68,6 +68,7 @@ import GI.Gtk
   , labelNew
   , notebookGetNPages
   , notebookNew
+  , notebookSetShowBorder
   , onEntryActivate
   , onNotebookPageRemoved
   , onNotebookPageReordered
@@ -365,6 +366,9 @@ setupTermonad tmConfig app win builder = do
   fontDesc <- createFontDescFromConfig tmConfig
   note <- notebookNew
   widgetSetCanFocus note False
+  -- If this is not set to False, then there will be a one pixel white border
+  -- shown around the notebook.
+  notebookSetShowBorder note False
   boxPackStart box note True True 0
 
   mvarTMState <- newEmptyTMState tmConfig app win note fontDesc


### PR DESCRIPTION
In #129, @ssbothwell reported that there was a stray one-pixel white border around the GtkNotebook.

@Reasonable-Solutions provided an easy way to debug these types of problems, as well as the solution to this particular problem.

This PR sets the Notebook so it doesn't have the one-pixel border.