### PR TITLE
README: add badge that monitors the dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ Termonad
 
 [![Build Status](https://secure.travis-ci.org/cdepillabout/termonad.svg)](http://travis-ci.org/cdepillabout/termonad)
 [![Hackage](https://img.shields.io/hackage/v/termonad.svg)](https://hackage.haskell.org/package/termonad)
+[![Release dependencies](https://img.shields.io/hackage-deps/v/termonad?label=Release%20dependencies)](https://packdeps.haskellers.com/feed?needle=termonad)
 [![Stackage LTS](http://stackage.org/package/termonad/badge/lts)](http://stackage.org/lts/package/termonad)
 [![Stackage Nightly](http://stackage.org/package/termonad/badge/nightly)](http://stackage.org/nightly/package/termonad)
 [![BSD3 license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)


### PR DESCRIPTION
Web service scanner works great.

Except one nitpick - it at the moment web service scanner does not respect deprecation of major placebo updates on Hackage, I opened a report on that upstream https://github.com/snoyberg/packdeps/issues/50

This badge should make monitoring of dependencies, and looking at what needs to be updated - easy and available for all your community.

The result can be observed here: https://github.com/Anton-Latukha/termonad/tree/patch-1

We see that `base` needs to be updated.