### PR TITLE
Get termonad working with latest version of nixpkgs and haskell-gi

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -20,13 +20,13 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # Recent version of nixpkgs master as of 2020-07-01 which uses LTS-16.2.
-          url = "https://github.com/NixOS/nixpkgs/archive/7db146538e49ad4bee4b5c4fea073c38586df7e2.tar.gz";
-          sha256 = "06vhwys3rpj6grxn76n1sj14wf4hn9z8bmd2k1yhcy29cqri0xhk";
+          # Recent version of nixpkgs master as of 2020-08-18 which uses LTS-16.9.
+          url = "https://github.com/NixOS/nixpkgs/archive/c5815280e92112a25d958a2ec8b3704d7d90c506.tar.gz";
+          sha256 = "09ic4s9s7w3lm0gmcxszm5j20cfv4n5lfvhdvgi7jzdbbbdps1nh";
         }
       else nixpkgs;
 
-  compilerVersion = if isNull compiler then "ghc883" else compiler;
+  compilerVersion = if isNull compiler then "ghc884" else compiler;
 
   # An overlay that adds termonad to all haskell package sets.
   haskellPackagesOverlay = self: super: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.0.0.1
+
+*   Update Termonad to be able to be built with the latest versions of the
+    haskell-gi libraries.  This shouldn't affect most users building with
+    `stack`. It is only used
+    [currently](https://github.com/NixOS/nixpkgs/pull/95434) for building
+    Termonad with packages from Nixpkgs.
+
 ## 4.0.0.0
 
 *   Remove the dependently typed code for specifying terminal colors.

--- a/shell.nix
+++ b/shell.nix
@@ -24,41 +24,6 @@
 # will also index the Termonad libraries, however this will mean the environment
 # will need to be rebuilt every time the termonad source changes.
 
-{ compiler ? null, indexTermonad ? false, nixpkgs ? null, additionalOverlays ? [] }:
+{ compiler ? null, indexTermonad ? false, nixpkgs ? null, additionalOverlays ? [] }@args:
 
-with (import .nix-helpers/nixpkgs.nix { inherit compiler nixpkgs additionalOverlays; });
-
-let
-  # A Haskell package set for a version of GHC that is known working.
-  haskPkgSet = termonadKnownWorkingHaskellPkgSet;
-
-  # Nix-shell environment for hacking on termonad.
-  termonadEnv = haskPkgSet.termonad.env;
-
-  # Build tools that are nice to have.  It is okay to get Haskell build tools
-  # from any Haskell package set, since they do not depend on the GHC version
-  # we are using.  We get these from the normal haskellPackages pkg set because
-  # then they don't have to be compiled from scratch.
-  nativeBuildTools = [
-    cabal-install
-    gnome3.glade
-    haskellPackages.ghcid
-  ];
-in
-
-if indexTermonad
-  then
-    termonadEnv.overrideAttrs (oldAttrs: {
-      nativeBuildInputs =
-        let
-          ghcEnvWithTermonad =
-            haskPkgSet.ghcWithHoogle (hpkgs: [ hpkgs.termonad ]);
-        in
-        oldAttrs.nativeBuildInputs ++ nativeBuildTools ++ [ ghcEnvWithTermonad ];
-    })
-  else
-    haskPkgSet.shellFor {
-      withHoogle = true;
-      packages = hpkgs: [ hpkgs.termonad ];
-      nativeBuildInputs = termonadEnv.nativeBuildInputs ++ nativeBuildTools;
-    }
+(import .nix-helpers/nixpkgs.nix args).termonadShell

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -295,8 +295,7 @@ unsafeMkMatrix :: [[[a]]] -> Matrix a
 unsafeMkMatrix xs =
   case mkMatrix xs of
     Just xs' -> xs'
-    Nothing  -> error "Matrix must be 6x6x6"
-    Nothing  ->
+    Nothing ->
       error $
         "unsafeMkMatrix: input list must be exactly 6x6x6"
 

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -19,15 +19,16 @@ import GI.Gdk
   )
 import GI.Gdk.Constants (pattern BUTTON_SECONDARY)
 import GI.Gio
-  ( menuAppend
+  ( Cancellable
+  , menuAppend
   , menuNew
-  , noCancellable
   )
 import GI.GLib
   ( SpawnFlags(SpawnFlagsDefault)
   )
 import GI.Gtk
-  ( Align(AlignFill)
+  ( Adjustment
+  , Align(AlignFill)
   , ApplicationWindow
   , Box
   , Button
@@ -55,7 +56,6 @@ import GI.Gtk
   , menuAttachToWidget
   , menuNewFromModel
   , menuPopupAtPointer
-  , noAdjustment
   , notebookAppendPage
   , notebookDetachTab
   , notebookGetNPages
@@ -254,7 +254,10 @@ createScrolledWin mvarTMState = do
   let showScrollbarVal =
         tmState ^. lensTMStateConfig . lensOptions . lensShowScrollbar
       vScrollbarPolicy = showScrollbarToPolicy showScrollbarVal
-  scrolledWin <- scrolledWindowNew noAdjustment noAdjustment
+  scrolledWin <-
+    scrolledWindowNew
+      (Nothing :: Maybe Adjustment)
+      (Nothing :: Maybe Adjustment)
   widgetShow scrolledWin
   scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy
   pure scrolledWin
@@ -370,7 +373,7 @@ launchShell vteTerm maybeCurrDir = do
       Nothing
       ([SpawnFlagsDefault] :: [SpawnFlags])
       Nothing
-      noCancellable
+      (Nothing :: Maybe Cancellable)
   pure (fromIntegral shellPid)
 
 -- | Add a page to the notebook and switch to it.

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - gi-vte-2.91.25
+  - gi-vte-2.91.27
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -9,7 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - gi-vte-2.91.27
+  - gi-vte-2.91.25
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-16.3
+resolver: lts-16.9
 
 # Local packages, usually specified by relative directory name
 packages:

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             4.0.0.0
+version:             4.0.0.1
 synopsis:            Terminal emulator configurable in Haskell
 description:         Please see <https://github.com/cdepillabout/termonad#readme README.md>.
 homepage:            https://github.com/cdepillabout/termonad


### PR DESCRIPTION
Nixpkgs was recently updated to use the latest haskell-gi versions: https://github.com/NixOS/nixpkgs/pull/95434.

Termonad needs a slight update to work with the latest haskell-gi version.