### PR TITLE
Option boldIsBright added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 4.1.0.0
+
+*   Add an option for enabling "bold is bright".  This forces colors from the
+    extended light palette to be used whenever Termonad prints bold text.
+    [#178](https://github.com/cdepillabout/termonad/pull/178).
+    Thanks [@M0M097](https://github.com/M0M097)!
+
 ## 4.0.1.2
 
 *   Disable doctest test-suite when building with GHC-8.10.3.  The doctests

--- a/glade/preferences.glade
+++ b/glade/preferences.glade
@@ -1,29 +1,28 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.22.1 -->
+<!-- Generated with glade 3.38.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkDialog" id="preferences">
-    <property name="can_focus">False</property>
+    <property name="can-focus">False</property>
     <property name="title" translatable="yes">Termonad Preferences</property>
-    <property name="window_position">center-on-parent</property>
-    <property name="type_hint">dialog</property>
-    <child type="titlebar">
-      <placeholder/>
-    </child>
+    <property name="window-position">center-on-parent</property>
+    <property name="type-hint">dialog</property>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can_focus">False</property>
-        <property name="margin_left">8</property>
-        <property name="margin_right">8</property>
-        <property name="margin_top">8</property>
-        <property name="margin_bottom">8</property>
+        <property name="can-focus">False</property>
+        <property name="margin-left">10</property>
+        <property name="margin-right">10</property>
+        <property name="margin-start">8</property>
+        <property name="margin-end">8</property>
+        <property name="margin-top">8</property>
+        <property name="margin-bottom">8</property>
         <property name="hexpand">True</property>
         <property name="orientation">vertical</property>
         <property name="spacing">10</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can_focus">False</property>
-            <property name="layout_style">end</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
             <child>
               <placeholder/>
             </child>
@@ -31,9 +30,9 @@
               <object class="GtkButton" id="ok">
                 <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -49,210 +48,231 @@
           </packing>
         </child>
         <child>
+          <!-- n-columns=2 n-rows=10 -->
           <object class="GtkGrid">
             <property name="visible">True</property>
-            <property name="can_focus">False</property>
+            <property name="can-focus">False</property>
             <property name="hexpand">True</property>
-            <property name="border_width">0</property>
-            <property name="row_spacing">6</property>
-            <property name="column_spacing">6</property>
+            <property name="border-width">0</property>
+            <property name="row-spacing">7</property>
+            <property name="column-spacing">10</property>
             <child>
               <object class="GtkFontButton" id="font">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="tooltip_text" translatable="yes">Font to use in the terminal.</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="tooltip-text" translatable="yes">Font to use in the terminal.</property>
                 <property name="hexpand">True</property>
                 <property name="vexpand">False</property>
                 <property name="font">Sans 12</property>
                 <property name="language">en-us</property>
-                <property name="preview_text"/>
+                <property name="preview-text"/>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Font:</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">0</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">0</property>
               </packing>
             </child>
             <child>
               <object class="GtkSpinButton" id="scrollbackLen">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">Number of lines to keep in the output of the terminal.</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">Number of lines to keep in the output of the terminal.</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Scrollback length:</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">2</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkCheckButton" id="confirmExit">
                 <property name="label" translatable="yes">Confirm exit</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Whether or not to pop-up a dialog asking if you are sure you want to exit when you close a tab or exit out of Termonad.</property>
-                <property name="halign">center</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Whether or not to pop-up a dialog asking if you are sure you want to exit when you close a tab or exit out of Termonad.</property>
+                <property name="halign">start</property>
+                <property name="draw-indicator">True</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">3</property>
-                <property name="width">2</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">7</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Word char exceptions:</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="wordCharExceptions">
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="tooltip_text" translatable="yes">When double-clicking on text in the terminal with the mouse, Termonad will use these characters to determine what to highlight.  Characters in this list will be counted as part of a word.  This makes it easy to highlight things like URLs or file paths.</property>
+                <property name="can-focus">True</property>
+                <property name="tooltip-text" translatable="yes">When double-clicking on text in the terminal with the mouse, Termonad will use these characters to determine what to highlight.  Characters in this list will be counted as part of a word.  This makes it easy to highlight things like URLs or file paths.</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkCheckButton" id="showMenu">
                 <property name="label" translatable="yes">Show menu</property>
                 <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">False</property>
-                <property name="tooltip_text" translatable="yes">Whether or not to show the menubar.  (This is the bar at the top that has the "File", "Edit", "View", etc buttons.)</property>
-                <property name="halign">center</property>
-                <property name="draw_indicator">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Whether or not to show the menubar.  (This is the bar at the top that has the "File", "Edit", "View", etc buttons.)</property>
+                <property name="halign">start</property>
+                <property name="draw-indicator">True</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">5</property>
-                <property name="width">2</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">8</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Cursor blink mode:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Show tabbar:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
+                <property name="can-focus">False</property>
                 <property name="label" translatable="yes">Show scrollbar:</property>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="showScrollbar">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Whether or not to show a scrollbar on the terminal.  "If Needed" only shows the scrollbar if the text on the terminal goes off the screen.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Whether or not to show a scrollbar on the terminal.  "If Needed" only shows the scrollbar if the text on the terminal goes off the screen.</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="showTabBar">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Whether or not to show the tab bar.  "If Needed" only shows the tab bar when you have multiple tabs.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Whether or not to show the tab bar.  "If Needed" only shows the tab bar when you have multiple tabs.</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">6</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">4</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBoxText" id="cursorBlinkMode">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="tooltip_text" translatable="yes">Set whether the cursor in the terminal should blink.  "System" sets this to the system-level GTK setting.</property>
+                <property name="can-focus">False</property>
+                <property name="tooltip-text" translatable="yes">Set whether the cursor in the terminal should blink.  "System" sets this to the system-level GTK setting.</property>
               </object>
               <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">7</property>
+                <property name="left-attach">1</property>
+                <property name="top-attach">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel" id="warning">
                 <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="margin_left">5</property>
-                <property name="margin_right">5</property>
-                <property name="margin_top">5</property>
-                <property name="margin_bottom">5</property>
+                <property name="can-focus">False</property>
+                <property name="margin-left">5</property>
+                <property name="margin-right">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
                 <property name="label" translatable="yes">Warning: these settings will be used for current session only. To make them permanent, set them in ~/.config/termonad/termonad.hs</property>
                 <property name="justify">fill</property>
                 <property name="wrap">True</property>
-                <property name="max_width_chars">30</property>
+                <property name="max-width-chars">30</property>
                 <attributes>
                   <attribute name="foreground" value="#ffff00000000"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">8</property>
+                <property name="left-attach">0</property>
+                <property name="top-attach">9</property>
                 <property name="width">2</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Show tabbar:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Cursor blink mode:</property>
+              </object>
+              <packing>
+                <property name="left-attach">0</property>
+                <property name="top-attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="boldIsBright">
+                <property name="label" translatable="yes">Bold is bright</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Control whether or not to force bold text to use colors from the light palette.
+
+If selected, then colored bold text will always use colors from the light palette.  There will be no way to print bold text colored with the standard palette. 
+
+If unselected, then bold can be applied separately to colors from both the standard and light palettes.</property>
+                <property name="halign">start</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
           </object>
           <packing>

--- a/src/Termonad/Lenses.hs
+++ b/src/Termonad/Lenses.hs
@@ -58,6 +58,7 @@ $(makeLensesFor
     , ("showMenu", "lensShowMenu")
     , ("showTabBar", "lensShowTabBar")
     , ("cursorBlinkMode", "lensCursorBlinkMode")
+    , ("boldIsBright", "lensBoldIsBright")
     ]
     ''ConfigOptions
  )

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -91,6 +91,7 @@ import GI.Vte
   , terminalSetScrollbackLines
   , terminalSpawnSync
   , terminalSetWordCharExceptions
+  , terminalSetBoldIsBright
   )
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
@@ -111,7 +112,7 @@ import Termonad.Lenses
   )
 import Termonad.Types
   ( ConfigHooks(createTermHook)
-  , ConfigOptions(scrollbackLen, wordCharExceptions, cursorBlinkMode)
+  , ConfigOptions(scrollbackLen, wordCharExceptions, cursorBlinkMode, boldIsBright)
   , ShowScrollbar(..)
   , ShowTabBar(..)
   , TMConfig(hooks, options)
@@ -346,6 +347,7 @@ createAndInitVteTerm tmStateFontDesc curOpts = do
   terminalSetWordCharExceptions vteTerm $ wordCharExceptions curOpts
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen curOpts))
   terminalSetCursorBlinkMode vteTerm (cursorBlinkMode curOpts)
+  terminalSetBoldIsBright vteTerm (boldIsBright curOpts)
   widgetShow vteTerm
   pure vteTerm
 

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -391,6 +391,8 @@ data ConfigOptions = ConfigOptions
     -- ^ When to show the tab bar.
   , cursorBlinkMode :: !CursorBlinkMode
     -- ^ How to handle cursor blink.
+  , boldIsBright :: !Bool
+    -- ^ Which color to use for bold text
   } deriving (Eq, Generic, FromJSON, Show, ToJSON)
 
 instance FromJSON CursorBlinkMode where
@@ -421,6 +423,7 @@ instance ToJSON CursorBlinkMode where
 --           , showMenu = True
 --           , showTabBar = ShowTabBarIfNeeded
 --           , cursorBlinkMode = CursorBlinkModeOn
+--           , boldIsBright = False
 --           }
 --   in defaultConfigOptions == defConfOpt
 -- :}
@@ -436,6 +439,7 @@ defaultConfigOptions =
     , showMenu = True
     , showTabBar = ShowTabBarIfNeeded
     , cursorBlinkMode = CursorBlinkModeOn
+    , boldIsBright = False
     }
 
 -- | The Termonad 'ConfigOptions' along with the 'ConfigHooks'.

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -392,7 +392,22 @@ data ConfigOptions = ConfigOptions
   , cursorBlinkMode :: !CursorBlinkMode
     -- ^ How to handle cursor blink.
   , boldIsBright :: !Bool
-    -- ^ Which color to use for bold text
+    -- ^ This option controls whether or not to force bold text to use colors
+    -- from the 'Termonad.Config.Colour.ExtendedPalatte'.
+    --
+    -- If 'True', then colored bold text will /always/ use colors from the
+    -- 'Termonad.Config.Colour.ExtendedPalatte'.  There will be no way to print
+    -- bold text colored with the 'Termonad.Config.Colour.BasicPalatte'.
+    --
+    -- This often isn't a big problem, since many TUI applications use
+    -- bold in combination with colors from the 'Termonad.Config.Colour.ExtendedPalatte'.
+    -- Also, the VTE default blue color can be difficult to read with a dark
+    -- background, and enabling this can work around the problem.
+    -- See <https://github.com/cdepillabout/termonad/issues/177> for more information.
+    --
+    -- If 'False', then bold can be applied separately to colors from both the
+    -- 'Termonad.Config.Colour.BasicPalatte' and
+    -- 'Termonad.Config.Colour.ExtendedPalatte'.
   } deriving (Eq, Generic, FromJSON, Show, ToJSON)
 
 instance FromJSON CursorBlinkMode where

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -152,6 +152,7 @@ test-suite doctests
   ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
   -- For some reason doctests appear to be segfaulting when compiling with
   -- ghc-8.10.3, so only build them when using ghc-8.10.2 or earlier.
+  -- See https://github.com/cdepillabout/termonad/issues/174.
   if impl(ghc <= 8.10.2)
     buildable:         True
   else

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             4.0.1.2
+version:             4.1.0.0
 synopsis:            Terminal emulator configurable in Haskell
 description:
   Termonad is a terminal emulator configurable in Haskell.  It is extremely


### PR DESCRIPTION
Added the option boldIsBright which is set to False by default. If set to True in termonad.hs this will lead to bright bold fonts. 

This solves the issue with the unreadable blue text on dark background since blue text is almost always used together with bold fonts. 

I would recommend to even set boldIsBright to True by default. 