### PR TITLE
add shortcuts to switch to the prev/next page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 4.1.1.0
+
+*   Add new shortcuts to switch to the next and previous tab:
+    <kbd>Ctrl</kbd><kbd>PgDown</kbd> and <kbd>Ctrl</kbd><kbd>PgUp</kbd>.
+    This works similar to gnome-terminal and xfce4-terminal.
+    [#180](https://github.com/cdepillabout/termonad/pull/180).
+    Thanks [@juliendehos](https://github.com/juliendehos)!
+
 ## 4.1.0.0
 
 *   Add an option for enabling "bold is bright".  This forces colors from the

--- a/README.md
+++ b/README.md
@@ -297,6 +297,8 @@ Termonad provides the following default key bindings.
 | <kbd>Ctrl</kbd> <kbd>Shift</kbd> <kbd>i</kbd> | Find the regex **below** the current position. |
 | <kbd>Ctrl</kbd> <kbd>+</kbd> | Increase font size. |
 | <kbd>Ctrl</kbd> <kbd>-</kbd> | Decrease font size. |
+| <kbd>Ctrl</kbd> <kbd>PgUp</kbd> | Switch to previous tab. |
+| <kbd>Ctrl</kbd> <kbd>PgDown</kbd> | Switch to next tab. |
 | <kbd>Alt</kbd> <kbd>(number key)</kbd> | Switch to tab `number`.  For example, <kbd>Alt</kbd> <kbd>2</kbd> switches to tab 2. |
 
 ### Configuring Termonad

--- a/README.md
+++ b/README.md
@@ -509,4 +509,3 @@ would like to add, please submit an issue or PR.
 ## Maintainers
 
 - [cdepillabout](https://github.com/cdepillabout)
-- [LSLeary](https://github.com/LSLeary)

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -68,6 +68,8 @@ import GI.Gtk
   , labelNew
   , notebookGetNPages
   , notebookNew
+  , notebookNextPage
+  , notebookPrevPage
   , notebookSetShowBorder
   , onEntryActivate
   , onNotebookPageRemoved
@@ -153,6 +155,8 @@ import Termonad.PreferencesFile (saveToPreferencesFile)
 import Termonad.Term
   ( createTerm
   , relabelTabs
+  , termNextPage
+  , termPrevPage
   , termExitFocused
   , setShowTabs
   , showScrollbarToPolicy
@@ -428,6 +432,18 @@ setupTermonad tmConfig app win builder = do
   void $ onSimpleActionActivate newTabAction $ \_ -> void $ createTerm handleKeyPress mvarTMState
   actionMapAddAction app newTabAction
   applicationSetAccelsForAction app "app.newtab" ["<Shift><Ctrl>T"]
+
+  nextPageAction <- simpleActionNew "nextpage" Nothing
+  void $ onSimpleActionActivate nextPageAction $ \_ ->
+    termNextPage mvarTMState
+  actionMapAddAction app nextPageAction
+  applicationSetAccelsForAction app "app.nextpage" ["<Ctrl>Page_Down"]
+
+  prevPageAction <- simpleActionNew "prevpage" Nothing
+  void $ onSimpleActionActivate prevPageAction $ \_ ->
+    termPrevPage mvarTMState
+  actionMapAddAction app prevPageAction
+  applicationSetAccelsForAction app "app.prevpage" ["<Ctrl>Page_Up"]
 
   closeTabAction <- simpleActionNew "closetab" Nothing
   void $ onSimpleActionActivate closeTabAction $ \_ ->

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -59,7 +59,9 @@ import GI.Gtk
   , notebookAppendPage
   , notebookDetachTab
   , notebookGetNPages
+  , notebookNextPage
   , notebookPageNum
+  , notebookPrevPage
   , notebookSetCurrentPage
   , notebookSetShowTabs
   , notebookSetTabReorderable
@@ -138,6 +140,16 @@ focusTerm i mvarTMState = do
 
 altNumSwitchTerm :: Int -> TMState -> IO ()
 altNumSwitchTerm = focusTerm
+
+termNextPage :: TMState -> IO ()
+termNextPage mvarTMState = do
+  note <- tmNotebook . tmStateNotebook <$> readMVar mvarTMState
+  notebookNextPage note
+
+termPrevPage :: TMState -> IO ()
+termPrevPage mvarTMState = do
+  note <- tmNotebook . tmStateNotebook <$> readMVar mvarTMState
+  notebookPrevPage note
 
 termExitFocused :: TMState -> IO ()
 termExitFocused mvarTMState = do

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             4.1.0.0
+version:             4.1.1.0
 synopsis:            Terminal emulator configurable in Haskell
 description:
   Termonad is a terminal emulator configurable in Haskell.  It is extremely


### PR DESCRIPTION
This PR adds 2 shortcuts: `<Ctrl>Page_Up` (switch to previous page) and `<Ctrl>Page_Down` (switch to next page). Inspired by gnome-terminal and xfce4-terminal.