### PR TITLE
Update README.md and remove irc #termonad badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Termonad
 [![Stackage Nightly](http://stackage.org/package/termonad/badge/nightly)](http://stackage.org/nightly/package/termonad)
 [![BSD3 license](https://img.shields.io/badge/license-BSD3-blue.svg)](./LICENSE)
 [![Join the chat at https://gitter.im/termonad/Lobby](https://badges.gitter.im/termonad/Lobby.svg)](https://gitter.im/termonad/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
-[![Join the chat in #termonad on irc.freenode.net](https://img.shields.io/badge/%23termonad-irc.freenode.net-brightgreen.svg)](https://webchat.freenode.net/)
 
 Termonad is a terminal emulator configurable in Haskell.  It is extremely
 customizable and provides hooks to modify the default behavior.  It can be


### PR DESCRIPTION
I don't hang out on the #termonad room on IRC, so I don't want users to think that they could get help directly from me there.

However, if there is someone that wants to officially take over helping using on the freenode #termonad room, I'd be happy to start directing people there as well.  (Although I should probably add a section to the readme about where to get help.)