### PR TITLE
Try bumping to ghc-8.10.4 to see if the doctests now work

### DIFF
--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -26,13 +26,13 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # Recent version of nixpkgs master as of 2020-12-27 which uses nightly-2020-12-14.
-          url = "https://github.com/NixOS/nixpkgs/archive/84917aa00bf23c88e5874c683abe05edb0ba4078.tar.gz";
-          sha256 = "1x3qh815d7k9yc72zpn5cfaaq2b1942q4pka6rx8b5i33yz4m61q";
+          # Recent version of nixpkgs haskell-updates as of 2021-02-11 which uses nightly-2021-02-10.
+          url = "https://github.com/NixOS/nixpkgs/archive/2ff53cedd652615a8409d30721e87ec7f4b43f20.tar.gz";
+          sha256 = "0sjan5x4n4l086lymqq83k5d0davpy0wblsz1j7wywi4svpsymrm";
         }
       else nixpkgs;
 
-  compilerVersion = if isNull compiler then "ghc8103" else compiler;
+  compilerVersion = if isNull compiler then "ghc8104" else compiler;
 
   # An overlay that adds termonad to all haskell package sets.
   haskellPackagesOverlay = self: super: {

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -153,10 +153,10 @@ test-suite doctests
   -- For some reason doctests appear to be segfaulting when compiling with
   -- ghc-8.10.3, so only build them when using ghc-8.10.2 or earlier.
   -- See https://github.com/cdepillabout/termonad/issues/174.
-  if impl(ghc <= 8.10.2)
-    buildable:         True
-  else
-    buildable:         False
+  -- if impl(ghc <= 8.10.2)
+  --   buildable:         True
+  -- else
+  --   buildable:         False
 
 test-suite termonad-test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
This is for https://github.com/cdepillabout/termonad/issues/174#issuecomment-777146380.

I try bumping the default compiler used by Nix to ghc-8.10.4 to see if it fixes the problem with the doctests failing.

The problems do not appear to be fixed.  The doctests are still occasionally failing, similar to ghc-8.10.3.