### PR TITLE
Update Stackage and Nixpkgs versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,9 @@ jobs:
         path: ${{ steps.setup-haskell-cabal.outputs.cabal-store }}
         key: ${{ runner.os }}-${{ matrix.ghc }}-cabal
 
+    - name: Update apt
+      run: sudo apt-get update
+
     - name: Install Required System Packages
       run: sudo apt-get install gobject-introspection libgirepository1.0-dev libgtk-3-dev libvte-2.91-dev libpcre2-dev
 
@@ -73,6 +76,9 @@ jobs:
       with:
         path: ~/.stack
         key: ${{ runner.os }}-stack-${{ matrix.resolver }}
+
+    - name: Update apt
+      run: sudo apt-get update
 
     - name: Install Required System Packages
       run: sudo apt-get install gobject-introspection libgirepository1.0-dev libgtk-3-dev libvte-2.91-dev libpcre2-dev

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,7 @@ jobs:
         cabal: ["latest"]
         ghc:
           - "8.8.4"
-          - "8.10.2" # doctests are disabled on 8.10.3, but still working on 8.10.2.
-          - "8.10.3"
+          - "8.10.4"
 
     steps:
     - uses: actions/checkout@v2
@@ -50,11 +49,14 @@ jobs:
         cabal test all --enable-tests
 
   stack:
-    name: stack / ubuntu-latest
+    name: stack ${{ matrix.resolver }} / ubuntu-latest
     runs-on: ubuntu-latest
     strategy:
       matrix:
         stack: ["latest"]
+        resolver:
+          - "--stack-yaml ./stack.yaml" # Stackage LTS
+          - "--stack-yaml ./stack-nightly.yaml" # Stackage Nightly
 
     steps:
     - uses: actions/checkout@v2
@@ -70,17 +72,17 @@ jobs:
       name: Cache ~/.stack
       with:
         path: ~/.stack
-        key: ${{ runner.os }}-stack
+        key: ${{ runner.os }}-stack-${{ matrix.resolver }}
 
     - name: Install Required System Packages
       run: sudo apt-get install gobject-introspection libgirepository1.0-dev libgtk-3-dev libvte-2.91-dev libpcre2-dev
 
     - name: Build
       run: |
-        stack build --test --bench --no-run-tests --no-run-benchmarks --flag termonad:buildexamples
+        stack ${{ matrix.resolver }} build --test --bench --no-run-tests --no-run-benchmarks --flag termonad:buildexamples
     - name: Test
       run: |
-        stack test --flag termonad:buildexamples
+        stack ${{ matrix.resolver }} test --flag termonad:buildexamples
 
   nix:
     name: nix / ubuntu-latest

--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -46,6 +46,8 @@ let
                 ".nix-helpers"
                 "result"
                 ".stack-work"
+                "stack.yaml"
+                "stack-nightly.yaml"
                 ".travis.yml"
               ];
 

--- a/.nix-helpers/nixpkgs.nix
+++ b/.nix-helpers/nixpkgs.nix
@@ -26,13 +26,13 @@ let
     if isNull nixpkgs
       then
         builtins.fetchTarball {
-          # Recent version of nixpkgs master as of 2020-12-27 which uses nightly-2020-12-14.
-          url = "https://github.com/NixOS/nixpkgs/archive/84917aa00bf23c88e5874c683abe05edb0ba4078.tar.gz";
-          sha256 = "1x3qh815d7k9yc72zpn5cfaaq2b1942q4pka6rx8b5i33yz4m61q";
+          # Recent version of nixpkgs master as of 2021-05-09 which uses nightly-2020-05-07.
+          url = "https://github.com/NixOS/nixpkgs/archive/1c16013bd6e94da748b41cc123c6b509a23eb440.tar.gz";
+          sha256 = "1m2wif0qnci0q14plbqlb95vx214pxqgw5li86lyw6hsiy7y3zfn";
         }
       else nixpkgs;
 
-  compilerVersion = if isNull compiler then "ghc8103" else compiler;
+  compilerVersion = if isNull compiler then "ghc8104" else compiler;
 
   # An overlay that adds termonad to all haskell package sets.
   haskellPackagesOverlay = self: super: {
@@ -51,7 +51,7 @@ let
 
               src =
                 builtins.filterSource
-                  (path: type: with self.stdenv.lib;
+                  (path: type: with self.lib;
                     ! elem (baseNameOf path) filesToIgnore &&
                     ! any (flip hasPrefix (baseNameOf path)) [ "dist" ".ghc" ]
                   )

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2020-12-14
+resolver: nightly-2021-05-09
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -10,7 +10,6 @@ packages:
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
   - gi-vte-2.91.27@sha256:22faf2c2333ca2fe90780d44defcc7b095c619b72f27b90c9de1f5e2a960a5e3,3731
-  - xml-html-qq-0.1.0.1@sha256:1e6dc32d764da2b80eed8809cdbee0cb1f57011fa95ad1d8fe5949c4d8bde568,2331
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-16.9
+resolver: lts-17.10
 
 # Local packages, usually specified by relative directory name
 packages:
@@ -9,7 +9,7 @@ packages:
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
-  - gi-vte-2.91.25
+  - gi-vte-2.91.27@sha256:22faf2c2333ca2fe90780d44defcc7b095c619b72f27b90c9de1f5e2a960a5e3,3731
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -149,14 +149,7 @@ test-suite doctests
                      , template-haskell
                      , termonad
   default-language:    Haskell2010
-  ghc-options:         -Wall -threaded -rtsopts -with-rtsopts=-N
-  -- For some reason doctests appear to be segfaulting when compiling with
-  -- ghc-8.10.3, so only build them when using ghc-8.10.2 or earlier.
-  -- See https://github.com/cdepillabout/termonad/issues/174.
-  if impl(ghc <= 8.10.2)
-    buildable:         True
-  else
-    buildable:         False
+  ghc-options:         -Wall
 
 test-suite termonad-test
   type:                exitcode-stdio-1.0


### PR DESCRIPTION
This also makes sure the doctests aren't run with `-rtsopts -N`, because this was causing them to segfault.