### PR TITLE
add support for old preference file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,20 @@
-## (next) 4.2.0.0
+## 4.2.0.0
 
 *   Add new options `highlightFgColour` and `highlightBgColour` for setting
     the color of highlighted text
     [#190](https://github.com/cdepillabout/termonad/pull/190).
     Thanks [@zanculmarktum](https://github.com/zanculmarktum)!
+
+*   Termonad creates a configuration file in `~/.config/termonad/termonad.yaml`
+    for use with the Preferences editor.  This is only used if you don't
+    have a `termonad.hs` file.
+
+    The configuration file loading code has been updated to be more robust in
+    loading configurations that are missing fields.  This means that if you
+    update Termonad from an old version, your preferences will still be able to
+    be loaded in most cases
+    [#191](https://github.com/cdepillabout/termonad/pull/191).  Thanks again
+    [@jecaro](https://github.com/jecaro)!
 
 ## 4.1.1.0
 

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -68,8 +68,6 @@ import GI.Gtk
   , labelNew
   , notebookGetNPages
   , notebookNew
-  , notebookNextPage
-  , notebookPrevPage
   , notebookSetShowBorder
   , onEntryActivate
   , onNotebookPageRemoved

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -50,6 +50,8 @@ module Termonad.Config.Colour
     , lensCursorBgColour
     , lensForegroundColour
     , lensBackgroundColour
+    , lensHighlightFgColour
+    , lensHighlightBgColour
     , lensPalette
     -- * Colour Extension
     , ColourExtension(..)

--- a/src/Termonad/PreferencesFile.hs
+++ b/src/Termonad/PreferencesFile.hs
@@ -111,6 +111,16 @@ readFileWithDefaults file = runExceptT $ do
 -- >>> let hash2 = HashMap.fromList [("hello", Number 2), ("goat", String "chicken")]
 -- >>> mergeObjVals (Object hash1) (Object hash2)
 -- Object (fromList [("bye",Number 100.0),("goat",String "chicken"),("hello",Number 1.0)])
+--
+-- 'Value's of different types will use the second 'Value':
+--
+-- >>> mergeObjVals Null (String "bye")
+-- String "bye"
+-- >>> mergeObjVals (Bool True) (Number 2)
+-- Number 2.0
+-- >>> mergeObjVals (Object mempty) (Bool False)
+-- Bool False
+--
 mergeObjVals
   :: Value
      -- ^ Value that has been set explicitly in the User's configuration

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -90,9 +90,10 @@ library
                      , QuickCheck
                      , text
                      , transformers
-                     , yaml
+                     , unordered-containers
                      , xml-conduit
                      , xml-html-qq
+                     , yaml
   default-language:    Haskell2010
   ghc-options:         -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates
   default-extensions:  DataKinds

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             4.1.1.0
+version:             4.2.0.0
 synopsis:            Terminal emulator configurable in Haskell
 description:
   Termonad is a terminal emulator configurable in Haskell.  It is extremely

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -64,6 +64,7 @@ library
   other-modules:       Paths_termonad
   build-depends:       base >= 4.13 && < 5
                      , adjunctions
+                     , aeson
                      , classy-prelude
                      , colour
                      , constraints


### PR DESCRIPTION
Fix #189

To be able to read old versions of the configuration file, we first read it as a JSON object then mconcat it with the `defaultConfigOptions`.

Note that we lose a bit of type safety here as any valid yaml file will now be accepted by termonad. But I think it is ok.