### PR TITLE
Build with GHC-9.0.2 with Nix by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ jobs:
         ghc:
           - "8.8.4"
           - "8.10.7"
+          - "9.0.2"
 
     steps:
     - uses: actions/checkout@v2

--- a/.nix-helpers/overlays.nix
+++ b/.nix-helpers/overlays.nix
@@ -85,7 +85,7 @@ let
         # then they don't have to be compiled from scratch.
         convenientNativeBuildTools = [
           self.cabal-install
-          self.gnome3.glade
+          self.glade
           self.haskellPackages.ghcid
           self.hlint
         ];

--- a/.nix-helpers/overlays.nix
+++ b/.nix-helpers/overlays.nix
@@ -58,7 +58,7 @@ let
     #
     # Either this, or termonadKnownWorkingHaskellPkgSet can be changed in an overlay
     # if you want to use a different GHC to build Termonad.
-    termonadCompilerVersion = "ghc8107";
+    termonadCompilerVersion = "ghc902";
 
     # A Haskell package set where we know the GHC version works to compile
     # Termonad.  This is basically just a shortcut so that other Nix files

--- a/.nix-helpers/stack-shell.nix
+++ b/.nix-helpers/stack-shell.nix
@@ -8,9 +8,9 @@ haskell.lib.buildStackProject {
   buildInputs = [
     cairo
     git
-    gnome3.vte
     gobjectIntrospection
     gtk3
+    vte
     zlib
   ];
   ghc = termonadKnownWorkingHaskellPkgSet.ghc;

--- a/flake.lock
+++ b/flake.lock
@@ -2,16 +2,16 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1630850248,
-        "narHash": "sha256-OzJi6Olf7mSVhGt3W7qOMVP5Qk1lH60zlHeCcITzfv0=",
+        "lastModified": 1645575067,
+        "narHash": "sha256-GoJYyj6eYv+NYODMj5ZHiunuRfj5dHsxBPafhjdZkDc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "23d5823337f4502dfa17e192d8c53a47cabcb6b4",
+        "rev": "2b5c8147f5889b57f16de48015e18381ee65f63a",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-unstable",
+        "ref": "haskell-updates",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,14 @@
   description = "A VTE-based terminal emulator configurable in Haskell";
 
   # Nixpkgs / NixOS version to use.
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  #
+  # TODO: Nixpkgs is switching to use GHC-9.0.2 as the default compiler as of
+  # 2022-02-21, but the switch has currently only happened on the
+  # haskell-updates branch.  This temporarily makes Termonad use that branch.
+  # When https://github.com/NixOS/nixpkgs/pull/160733 is merged into master,
+  # switch back to nixos-unstable.
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/haskell-updates";
+  # inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs = { self, nixpkgs }:
     let

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -1,15 +1,14 @@
 # For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2021-05-09
+resolver: nightly-2022-02-19
 
 # Local packages, usually specified by relative directory name
 packages:
     - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps:
-  - gi-vte-2.91.27@sha256:22faf2c2333ca2fe90780d44defcc7b095c619b72f27b90c9de1f5e2a960a5e3,3731
+extra-deps: []
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -8,7 +8,9 @@ packages:
     - '.'
 
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
+extra-deps:
+  # Not in stackage nightly
+  - xml-html-qq-0.1.0.1@sha256:1e6dc32d764da2b80eed8809cdbee0cb1f57011fa95ad1d8fe5949c4d8bde568,2331
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack-nightly.yaml
+++ b/stack-nightly.yaml
@@ -10,6 +10,7 @@ packages:
 # Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
 extra-deps:
   # Not in stackage nightly
+  - heterocephalus-1.0.5.5@sha256:a0f0f5945378915fc6716eaa7e79f3489db420c54dd55c8346c2f9cdc2d0977c,2925
   - xml-html-qq-0.1.0.1@sha256:1e6dc32d764da2b80eed8809cdbee0cb1f57011fa95ad1d8fe5949c4d8bde568,2331
 
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
This PR switches the Nix files for Termonad to build with GHC-9.0.2 by default.

This is in preparation for getting Termonad working in Nixpkgs, which is currently in the process of switching from GHC-8.10.7 to GHC-9.0.2 as the default Haskell compiler: https://github.com/NixOS/nixpkgs/pull/160733