### PR TITLE
Add enableSixel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,8 @@ jobs:
         cabal test all --enable-tests
 
   stack:
-    name: stack ${{ matrix.resolver }} / ubuntu-latest
-    runs-on: ubuntu-latest
+    name: stack ${{ matrix.resolver }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         stack: ["latest"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,11 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-latest
+          # Termonad sometimes requires VTE features that are only in recent releases of VTE.
+          # Older versions of Ubuntu may not have a new enough VTE, so we test on multiple
+          # versions of Ubuntu (and therefore multiple versions of VTE).
+          - ubuntu-22.04
+          - ubuntu-20.04
           # - macOS-latest
         cabal: ["latest"]
         ghc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,13 @@ jobs:
         resolver:
           - "--stack-yaml ./stack.yaml" # Stackage LTS
           - "--stack-yaml ./stack-nightly.yaml" # Stackage Nightly
+        os:
+          # Termonad sometimes requires VTE features that are only in recent releases of VTE.
+          # Older versions of Ubuntu may not have a new enough VTE, so we test on multiple
+          # versions of Ubuntu (and therefore multiple versions of VTE).
+          - ubuntu-22.04
+          - ubuntu-20.04
+          # - macOS-latest
 
     steps:
     - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 4.3.0.0
+
+*   Add SIXEL support.  Note that you will need to set `enableSixel` to `True`
+    in your `ConfigOptions`, as well as using a version of VTE that is >= 0.63
+    for this option to have any affect.  There is also a report that even if you
+    enable SIXEL and have a supported version of VTE, SIXEL doesn't work.  See
+    the linked PR for more information. Thanks [@junjihashimoto](https://github.com/junjihashimoto)!
+    [#219](https://github.com/cdepillabout/termonad/pull/219)
+
 ## 4.2.0.1
 
 *   Added an

--- a/Setup.hs
+++ b/Setup.hs
@@ -104,6 +104,7 @@ createVteVersionCPPOpts
 createVteVersionCPPOpts vers =
   catMaybes
     [ if vers >= mkVersion [0,44] then Just "-DVTE_VERSION_GEQ_0_44" else Nothing
+    , if vers >= mkVersion [0,63] then Just "-DVTE_VERSION_GEQ_0_63" else Nothing
     ]
 
 -- | Based on the version of the GTK3 library as reported by @pkg-config@, return

--- a/glade/preferences.glade
+++ b/glade/preferences.glade
@@ -266,6 +266,21 @@ If unselected, then bold can be applied separately to colors from both the stand
               </packing>
             </child>
             <child>
+              <object class="GtkCheckButton" id="enableSixel">
+                <property name="label" translatable="yes">Enable sixel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">False</property>
+                <property name="tooltip-text" translatable="yes">Enable sixel to draw graphics</property>
+                <property name="halign">start</property>
+                <property name="draw-indicator">True</property>
+              </object>
+              <packing>
+                <property name="left-attach">1</property>
+                <property name="top-attach">10</property>
+              </packing>
+            </child>
+            <child>
               <placeholder/>
             </child>
             <child>

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -117,12 +117,10 @@ import GI.Vte
   , terminalSearchSetWrapAround
   , terminalSetBoldIsBright
   , terminalSetCursorBlinkMode
+  , terminalSetEnableSixel
   , terminalSetFont
   , terminalSetScrollbackLines
   , terminalSetWordCharExceptions
-  )
-import GI.Vte.Objects.Terminal
-  ( setTerminalEnableSixel
   )
 import System.Environment (getExecutablePath)
 import System.FilePath (takeFileName)
@@ -731,7 +729,7 @@ applyNewPreferencesToTab mvarTMState tab = do
   terminalSetWordCharExceptions term (wordCharExceptions options)
   terminalSetScrollbackLines term (fromIntegral (scrollbackLen options))
   terminalSetBoldIsBright term (boldIsBright options)
-  setTerminalEnableSixel term (enableSixel options)
+  terminalSetEnableSixel term (enableSixel options)
 
   let vScrollbarPolicy = showScrollbarToPolicy (options ^. lensShowScrollbar)
   scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -121,6 +121,9 @@ import GI.Vte
   , terminalSetScrollbackLines
   , terminalSetWordCharExceptions
   )
+import GI.Vte.Objects.Terminal
+  ( setTerminalEnableSixel
+  )
 import System.Environment (getExecutablePath)
 import System.FilePath (takeFileName)
 
@@ -129,6 +132,7 @@ import Termonad.Gtk (appNew, objFromBuildUnsafe)
 import Termonad.Keys (handleKeyPress)
 import Termonad.Lenses
   ( lensBoldIsBright
+  , lensEnableSixel
   , lensConfirmExit
   , lensCursorBlinkMode
   , lensFontConfig
@@ -727,6 +731,7 @@ applyNewPreferencesToTab mvarTMState tab = do
   terminalSetWordCharExceptions term (wordCharExceptions options)
   terminalSetScrollbackLines term (fromIntegral (scrollbackLen options))
   terminalSetBoldIsBright term (boldIsBright options)
+  setTerminalEnableSixel term (enableSixel options)
 
   let vScrollbarPolicy = showScrollbarToPolicy (options ^. lensShowScrollbar)
   scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy
@@ -752,6 +757,8 @@ showPreferencesDialog mvarTMState = do
     objFromBuildUnsafe preferencesBuilder "showMenu" CheckButton
   boldIsBrightCheckButton <-
     objFromBuildUnsafe preferencesBuilder "boldIsBright" CheckButton
+  enableSixelCheckButton <-
+    objFromBuildUnsafe preferencesBuilder "enableSixel" CheckButton
   wordCharExceptionsEntryBuffer <-
     objFromBuildUnsafe preferencesBuilder "wordCharExceptions" Entry >>=
       getEntryBuffer
@@ -806,6 +813,7 @@ showPreferencesDialog mvarTMState = do
   toggleButtonSetActive confirmExitCheckButton $ confirmExit options
   toggleButtonSetActive showMenuCheckButton $ showMenu options
   toggleButtonSetActive boldIsBrightCheckButton $ boldIsBright options
+  toggleButtonSetActive enableSixelCheckButton $ enableSixel options
   entryBufferSetText wordCharExceptionsEntryBuffer (wordCharExceptions options) (-1)
 
   -- Run dialog then close
@@ -827,6 +835,7 @@ showPreferencesDialog mvarTMState = do
     confirmExitVal <- toggleButtonGetActive confirmExitCheckButton
     showMenuVal <- toggleButtonGetActive showMenuCheckButton
     boldIsBrightVal <- toggleButtonGetActive boldIsBrightCheckButton
+    enableSixelVal <- toggleButtonGetActive enableSixelCheckButton
     wordCharExceptionsVal <- entryBufferGetText wordCharExceptionsEntryBuffer
 
     -- Apply the changes to mvarTMState
@@ -836,6 +845,7 @@ showPreferencesDialog mvarTMState = do
         ( set lensConfirmExit confirmExitVal
         . set lensShowMenu showMenuVal
         . set lensBoldIsBright boldIsBrightVal
+        . set lensEnableSixel enableSixelVal
         . set lensWordCharExceptions wordCharExceptionsVal
         . over lensFontConfig (`fromMaybe` maybeFontConfig)
         . set lensScrollbackLen scrollbackLenVal

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -117,7 +117,6 @@ import GI.Vte
   , terminalSearchSetWrapAround
   , terminalSetBoldIsBright
   , terminalSetCursorBlinkMode
-  , terminalSetEnableSixel
   , terminalSetFont
   , terminalSetScrollbackLines
   , terminalSetWordCharExceptions
@@ -126,7 +125,7 @@ import System.Environment (getExecutablePath)
 import System.FilePath (takeFileName)
 
 import Paths_termonad (getDataFileName)
-import Termonad.Gtk (appNew, objFromBuildUnsafe)
+import Termonad.Gtk (appNew, objFromBuildUnsafe, terminalSetEnableSixelIfExists)
 import Termonad.Keys (handleKeyPress)
 import Termonad.Lenses
   ( lensBoldIsBright
@@ -729,7 +728,7 @@ applyNewPreferencesToTab mvarTMState tab = do
   terminalSetWordCharExceptions term (wordCharExceptions options)
   terminalSetScrollbackLines term (fromIntegral (scrollbackLen options))
   terminalSetBoldIsBright term (boldIsBright options)
-  terminalSetEnableSixel term (enableSixel options)
+  terminalSetEnableSixelIfExists term (enableSixel options)
 
   let vScrollbarPolicy = showScrollbarToPolicy (options ^. lensShowScrollbar)
   scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy

--- a/src/Termonad/Lenses.hs
+++ b/src/Termonad/Lenses.hs
@@ -59,6 +59,7 @@ $(makeLensesFor
     , ("showTabBar", "lensShowTabBar")
     , ("cursorBlinkMode", "lensCursorBlinkMode")
     , ("boldIsBright", "lensBoldIsBright")
+    , ("enableSixel", "lensEnableSixel")
     ]
     ''ConfigOptions
  )

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -95,6 +95,9 @@ import GI.Vte
   , terminalSetWordCharExceptions
   , terminalSetBoldIsBright
   )
+import GI.Vte.Objects.Terminal
+  ( setTerminalEnableSixel
+  )
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
 
@@ -114,7 +117,7 @@ import Termonad.Lenses
   )
 import Termonad.Types
   ( ConfigHooks(createTermHook)
-  , ConfigOptions(scrollbackLen, wordCharExceptions, cursorBlinkMode, boldIsBright)
+  , ConfigOptions(scrollbackLen, wordCharExceptions, cursorBlinkMode, boldIsBright, enableSixel)
   , ShowScrollbar(..)
   , ShowTabBar(..)
   , TMConfig(hooks, options)
@@ -360,6 +363,7 @@ createAndInitVteTerm tmStateFontDesc curOpts = do
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen curOpts))
   terminalSetCursorBlinkMode vteTerm (cursorBlinkMode curOpts)
   terminalSetBoldIsBright vteTerm (boldIsBright curOpts)
+  setTerminalEnableSixel vteTerm (enableSixel curOpts)
   widgetShow vteTerm
   pure vteTerm
 

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -90,7 +90,6 @@ import GI.Vte
   , terminalNew
   , terminalSetBoldIsBright
   , terminalSetCursorBlinkMode
-  , terminalSetEnableSixel
   , terminalSetFont
   , terminalSetScrollbackLines
   , terminalSetWordCharExceptions
@@ -99,6 +98,7 @@ import GI.Vte
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
 
+import Termonad.Gtk (terminalSetEnableSixelIfExists)
 import Termonad.Lenses
   ( lensConfirmExit
   , lensOptions
@@ -361,7 +361,7 @@ createAndInitVteTerm tmStateFontDesc curOpts = do
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen curOpts))
   terminalSetCursorBlinkMode vteTerm (cursorBlinkMode curOpts)
   terminalSetBoldIsBright vteTerm (boldIsBright curOpts)
-  terminalSetEnableSixel vteTerm (enableSixel curOpts)
+  terminalSetEnableSixelIfExists vteTerm (enableSixel curOpts)
   widgetShow vteTerm
   pure vteTerm
 

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -88,15 +88,13 @@ import GI.Vte
   , onTerminalWindowTitleChanged
   , terminalGetWindowTitle
   , terminalNew
+  , terminalSetBoldIsBright
   , terminalSetCursorBlinkMode
+  , terminalSetEnableSixel
   , terminalSetFont
   , terminalSetScrollbackLines
-  , terminalSpawnSync
   , terminalSetWordCharExceptions
-  , terminalSetBoldIsBright
-  )
-import GI.Vte.Objects.Terminal
-  ( setTerminalEnableSixel
+  , terminalSpawnSync
   )
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
@@ -363,7 +361,7 @@ createAndInitVteTerm tmStateFontDesc curOpts = do
   terminalSetScrollbackLines vteTerm (fromIntegral (scrollbackLen curOpts))
   terminalSetCursorBlinkMode vteTerm (cursorBlinkMode curOpts)
   terminalSetBoldIsBright vteTerm (boldIsBright curOpts)
-  setTerminalEnableSixel vteTerm (enableSixel curOpts)
+  terminalSetEnableSixel vteTerm (enableSixel curOpts)
   widgetShow vteTerm
   pure vteTerm
 

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -408,6 +408,8 @@ data ConfigOptions = ConfigOptions
     -- If 'False', then bold can be applied separately to colors from both the
     -- 'Termonad.Config.Colour.BasicPalatte' and
     -- 'Termonad.Config.Colour.ExtendedPalatte'.
+  , enableSixel :: !Bool
+    -- ^ Enable sixel to draw graphics in a terminal.
   } deriving (Eq, Generic, FromJSON, Show, ToJSON)
 
 instance FromJSON CursorBlinkMode where
@@ -439,6 +441,7 @@ instance ToJSON CursorBlinkMode where
 --           , showTabBar = ShowTabBarIfNeeded
 --           , cursorBlinkMode = CursorBlinkModeOn
 --           , boldIsBright = False
+--           , enableSixel = True
 --           }
 --   in defaultConfigOptions == defConfOpt
 -- :}
@@ -455,6 +458,7 @@ defaultConfigOptions =
     , showTabBar = ShowTabBarIfNeeded
     , cursorBlinkMode = CursorBlinkModeOn
     , boldIsBright = False
+    , enableSixel = True
     }
 
 -- | The Termonad 'ConfigOptions' along with the 'ConfigHooks'.

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -409,7 +409,10 @@ data ConfigOptions = ConfigOptions
     -- 'Termonad.Config.Colour.BasicPalatte' and
     -- 'Termonad.Config.Colour.ExtendedPalatte'.
   , enableSixel :: !Bool
-    -- ^ Enable sixel to draw graphics in a terminal.
+    -- ^ Enable SIXEL to draw graphics in a terminal.
+    --
+    -- Note that SIXEL may not be fully supported in VTE. Follow
+    -- <https://gitlab.gnome.org/GNOME/vte/-/issues/253> for more information.
   } deriving (Eq, Generic, FromJSON, Show, ToJSON)
 
 instance FromJSON CursorBlinkMode where
@@ -441,7 +444,7 @@ instance ToJSON CursorBlinkMode where
 --           , showTabBar = ShowTabBarIfNeeded
 --           , cursorBlinkMode = CursorBlinkModeOn
 --           , boldIsBright = False
---           , enableSixel = True
+--           , enableSixel = False
 --           }
 --   in defaultConfigOptions == defConfOpt
 -- :}
@@ -458,7 +461,7 @@ defaultConfigOptions =
     , showTabBar = ShowTabBarIfNeeded
     , cursorBlinkMode = CursorBlinkModeOn
     , boldIsBright = False
-    , enableSixel = True
+    , enableSixel = False
     }
 
 -- | The Termonad 'ConfigOptions' along with the 'ConfigHooks'.

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -1,5 +1,5 @@
 name:                termonad
-version:             4.2.0.1
+version:             4.3.0.0
 synopsis:            Terminal emulator configurable in Haskell
 description:
   Termonad is a terminal emulator configurable in Haskell.  It is extremely


### PR DESCRIPTION
Hi, this pr adds the option of enable-sixel.
However, even if the option is enabled, the image of sixel is not shown. The vte supporting sixel may not be released.
https://gitlab.gnome.org/GNOME/vte/-/issues/253