### PR TITLE
Make code example up-to-date

### DIFF
--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -21,10 +21,12 @@
 --
 --  main :: IO ()
 --  main = 'start' $ 'defaultTMConfig'
---    { 'showScrollbar' = 'ShowScrollbarNever'
---    , 'confirmExit' = False
---    , 'showMenu' = False
---    , 'cursorBlinkMode' = 'CursorBlinkModeOff'
+--    { `options` = `defaultConfigOptions`
+--      { 'showScrollbar' = 'ShowScrollbarNever'
+--      , 'confirmExit' = False
+--      , 'showMenu' = False
+--      , 'cursorBlinkMode' = 'CursorBlinkModeOff'
+--      }
 --    }
 -- @
 --

--- a/src/Termonad/Config.hs
+++ b/src/Termonad/Config.hs
@@ -21,7 +21,7 @@
 --
 --  main :: IO ()
 --  main = 'start' $ 'defaultTMConfig'
---    { `options` = `defaultConfigOptions`
+--    { 'options' = 'defaultConfigOptions'
 --      { 'showScrollbar' = 'ShowScrollbarNever'
 --      , 'confirmExit' = False
 --      , 'showMenu' = False


### PR DESCRIPTION
Haddock documentation was obsolete, so I updated it to be fully valid Haskell term according to current Termonad API.