### PR TITLE
Add support for controlling multiple windows in one Termonad process

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -56,8 +56,17 @@
 # Ignore some builtin hints
 # - ignore: {name: Use let}
 # - ignore: {name: Use const, within: SpecialModule} # Only within certain modules
-- ignore: {name: Use forM_}
-- ignore: {name: Use join}
+- ignore: {name: "Eta reduce"}
+- ignore: {name: "Redundant pure"}
+- ignore: {name: "Replace case with maybe"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Use <$>"}
+- ignore: {name: "Use forM_"}
+- ignore: {name: "Use foldr"}
+- ignore: {name: "Use infix"}
+- ignore: {name: "Use join"}
+- ignore: {name: "Use uncurry"}
+
 
 
 # Define some custom infix operators

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -5,7 +5,7 @@ module Termonad.App where
 import Termonad.Prelude
 
 import Config.Dyre (wrapMain, newParams)
-import Control.Lens ((.~), (^.), (^..), over, set, view, ix)
+import Control.Lens ((^.), (^..), over, set, view, ix)
 import Control.Monad.Fail (fail)
 import Data.FileEmbed (embedFile)
 import Data.FocusList (focusList, moveFromToFL, updateFocusFL)
@@ -95,7 +95,7 @@ import GI.Gtk
   , widgetShow
   , widgetShowAll
   , windowPresent
-  , windowSetIcon
+  , windowSetDefaultIcon
   , windowSetTitle
   , windowSetTransientFor
   )
@@ -145,7 +145,6 @@ import Termonad.Lenses
   , lensShowScrollbar
   , lensShowTabBar
   , lensScrollbackLen
-  , lensTMNotebook
   , lensTMNotebookTabTermContainer
   , lensTMNotebookTabs
   , lensTMNotebookTabTerm
@@ -174,13 +173,21 @@ import Termonad.Types
   , TMConfig
   , TMNotebookTab
   , TMState
-  , TMState'(TMState)
+  , TMState'
+  , TMWindowId
   , getFocusedTermFromState
+  , getTMNotebookFromTMState
+  , getTMNotebookFromTMState'
+  , getTMWindowFromTMState'
   , modFontSize
   , newEmptyTMState
+  , tmNotebook
   , tmNotebookTabTermContainer
   , tmNotebookTabs
-  , tmStateApp, getTMNotebookFromTMState, TMWindowId, getTMNotebookFromTMState', tmNotebook, getTMWindowFromTMState', tmWindowAppWin, tmWindowNotebook, tmStateWindows
+  , tmStateApp
+  , tmStateWindows
+  , tmWindowAppWin
+  , tmWindowNotebook
   )
 import Termonad.XML (interfaceText, menuText, preferencesText)
 import Termonad.Cli (parseCliArgs, applyCliArgs)
@@ -380,10 +387,6 @@ forceQuit mvarTMState = do
 
 setupTermonad :: TMConfig -> Application -> ApplicationWindow -> Gtk.Builder -> IO ()
 setupTermonad tmConfig app win builder = do
-  let img = $(embedFile "img/termonad-lambda.png")
-  iconPixbuf <- imgToPixbuf img
-  windowSetIcon win (Just iconPixbuf)
-
   setupScreenStyle
   box <- objFromBuildUnsafe builder "content_box" Box
   fontDesc <- createFontDescFromConfig tmConfig
@@ -550,6 +553,9 @@ setupTermonad tmConfig app win builder = do
 
 appActivate :: TMConfig -> Application -> IO ()
 appActivate tmConfig app = do
+  let img = $(embedFile "img/termonad-lambda.png")
+  iconPixbuf <- imgToPixbuf img
+  windowSetDefaultIcon iconPixbuf
   uiBuilder <-
     builderNewFromString interfaceText $ fromIntegral (Text.length interfaceText)
   builderSetApplication uiBuilder app

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -445,26 +445,26 @@ setupTermonad tmConfig app win builder = do
   newTabAction <- simpleActionNew "newtab" Nothing
   void $ onSimpleActionActivate newTabAction $ \_ ->
     void $ createTerm handleKeyPress mvarTMState tmWinId
-  actionMapAddAction app newTabAction
+  actionMapAddAction win newTabAction
   applicationSetAccelsForAction app "win.newtab" ["<Shift><Ctrl>T"]
 
   nextPageAction <- simpleActionNew "nextpage" Nothing
   void $ onSimpleActionActivate nextPageAction $ \_ ->
     termNextPage mvarTMState tmWinId
-  actionMapAddAction app nextPageAction
+  actionMapAddAction win nextPageAction
   applicationSetAccelsForAction app "win.nextpage" ["<Ctrl>Page_Down"]
 
   prevPageAction <- simpleActionNew "prevpage" Nothing
   void $ onSimpleActionActivate prevPageAction $ \_ ->
     termPrevPage mvarTMState tmWinId
-  actionMapAddAction app prevPageAction
-  applicationSetAccelsForAction app "app.prevpage" ["<Ctrl>Page_Up"]
+  actionMapAddAction win prevPageAction
+  applicationSetAccelsForAction app "win.prevpage" ["<Ctrl>Page_Up"]
 
   closeTabAction <- simpleActionNew "closetab" Nothing
   void $ onSimpleActionActivate closeTabAction $ \_ ->
     termExitFocused mvarTMState tmWinId
-  actionMapAddAction app closeTabAction
-  applicationSetAccelsForAction app "app.closetab" ["<Shift><Ctrl>W"]
+  actionMapAddAction win closeTabAction
+  applicationSetAccelsForAction app "win.closetab" ["<Shift><Ctrl>W"]
 
   quitAction <- simpleActionNew "quit" Nothing
   void $ onSimpleActionActivate quitAction $ \_ -> do
@@ -477,15 +477,15 @@ setupTermonad tmConfig app win builder = do
   void $ onSimpleActionActivate copyAction $ \_ -> do
     maybeTerm <- getFocusedTermFromState mvarTMState tmWinId
     maybe (pure ()) terminalCopyClipboard maybeTerm
-  actionMapAddAction app copyAction
-  applicationSetAccelsForAction app "app.copy" ["<Shift><Ctrl>C"]
+  actionMapAddAction win copyAction
+  applicationSetAccelsForAction app "win.copy" ["<Shift><Ctrl>C"]
 
   pasteAction <- simpleActionNew "paste" Nothing
   void $ onSimpleActionActivate pasteAction $ \_ -> do
     maybeTerm <- getFocusedTermFromState mvarTMState tmWinId
     maybe (pure ()) terminalPasteClipboard maybeTerm
-  actionMapAddAction app pasteAction
-  applicationSetAccelsForAction app "app.paste" ["<Shift><Ctrl>V"]
+  actionMapAddAction win pasteAction
+  applicationSetAccelsForAction app "win.paste" ["<Shift><Ctrl>V"]
 
   preferencesAction <- simpleActionNew "preferences" Nothing
   void $ onSimpleActionActivate preferencesAction (const $ showPreferencesDialog mvarTMState)
@@ -505,18 +505,18 @@ setupTermonad tmConfig app win builder = do
 
   findAction <- simpleActionNew "find" Nothing
   void $ onSimpleActionActivate findAction $ \_ -> doFind mvarTMState tmWinId
-  actionMapAddAction app findAction
-  applicationSetAccelsForAction app "app.find" ["<Shift><Ctrl>F"]
+  actionMapAddAction win findAction
+  applicationSetAccelsForAction app "win.find" ["<Shift><Ctrl>F"]
 
   findAboveAction <- simpleActionNew "findabove" Nothing
   void $ onSimpleActionActivate findAboveAction $ \_ -> findAbove mvarTMState tmWinId
-  actionMapAddAction app findAboveAction
-  applicationSetAccelsForAction app "app.findabove" ["<Shift><Ctrl>P"]
+  actionMapAddAction win findAboveAction
+  applicationSetAccelsForAction app "win.findabove" ["<Shift><Ctrl>P"]
 
   findBelowAction <- simpleActionNew "findbelow" Nothing
   void $ onSimpleActionActivate findBelowAction $ \_ -> findBelow mvarTMState tmWinId
-  actionMapAddAction app findBelowAction
-  applicationSetAccelsForAction app "app.findbelow" ["<Shift><Ctrl>I"]
+  actionMapAddAction win findBelowAction
+  applicationSetAccelsForAction app "win.findbelow" ["<Shift><Ctrl>I"]
 
   aboutAction <- simpleActionNew "about" Nothing
   void $ onSimpleActionActivate aboutAction $ \_ -> showAboutDialog app

--- a/src/Termonad/Cli.hs
+++ b/src/Termonad/Cli.hs
@@ -15,9 +15,11 @@ module Termonad.Cli where
 
 import Termonad.Prelude
 
+import Control.Applicative ((<|>), (<**>))
+import Data.Text (pack)
+import GI.Vte (CursorBlinkMode)
 import Options.Applicative (fullDesc, info, helper, progDesc, ParserInfo, execParser, Parser, Mod, OptionFields, option, str, value, short, long, metavar, help, ReadM, maybeReader, auto, flag')
 import Termonad.Types (ConfigOptions (..), Option (Set, Unset), ShowScrollbar, FontSize (..), ShowTabBar, showScrollbarFromString, showTabBarFromString, cursorBlinkModeFromString, FontConfig (..))
-import GI.Vte (CursorBlinkMode)
 
 
 -- | A data type that contains arguments from the command line.

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -661,6 +661,12 @@ showColourCube matrix =
     showCol :: AlphaColour Double -> String -> String
     showCol col str = sRGB32show col <> str
 
+    -- A version of head that gives a better error message.
+    headEx :: forall b. [b] -> b
+    headEx = \case
+      [] -> error "showColourCube: error in headEx, passed empty list, this is likely a logic error"
+      (h : _) -> h
+
 -- | A List of a grey scale.  Default value for 'FullPalette'.
 --
 -- >>> fmap sRGB32show defaultGreyscale

--- a/src/Termonad/Config/Colour.hs
+++ b/src/Termonad/Config/Colour.hs
@@ -552,7 +552,7 @@ cube d i j k =
     coef x = fromIntegral x / 5
 -- | A matrix of a 6 x 6 x 6 color cube. Default value for 'ColourCubePalette'.
 --
--- >>> putStrLn $ pack $ showColourCube defaultColourCube
+-- >>> putStrLn $ showColourCube defaultColourCube
 -- [ [ #000000ff, #00005fff, #000087ff, #0000afff, #0000d7ff, #0000ffff
 --   , #005f00ff, #005f5fff, #005f87ff, #005fafff, #005fd7ff, #005fffff
 --   , #008700ff, #00875fff, #008787ff, #0087afff, #0087d7ff, #0087ffff

--- a/src/Termonad/Gtk.hs
+++ b/src/Termonad/Gtk.hs
@@ -19,6 +19,7 @@ import Termonad.Prelude
 
 import Control.Monad.Fail (MonadFail, fail)
 import Data.GI.Base (ManagedPtr, withManagedPtr)
+import Data.Text (unpack)
 import GHC.Stack (HasCallStack)
 import GI.Gdk
   ( GObject
@@ -42,15 +43,11 @@ objFromBuildUnsafe ::
 objFromBuildUnsafe builder name constructor = do
   maybePlainObj <- builderGetObject builder name
   case maybePlainObj of
-    Nothing -> error $ "Couldn't get " <> unpack name <> " from builder!"
+    Nothing -> error $ unpack $ "Couldn't get " <> name <> " from builder!"
     Just plainObj -> do
       maybeNewObj <- castTo constructor plainObj
       case maybeNewObj of
-        Nothing ->
-          error $
-            "Got " <>
-            unpack name <>
-            " from builder, but couldn't convert to object!"
+        Nothing -> error $ unpack $ "Got " <> name <> " from builder, but couldn't convert to object!"
         Just obj -> pure obj
 
 -- | Unsafely creates a new 'Application'.  This calls 'fail' if it cannot

--- a/src/Termonad/IdMap.hs
+++ b/src/Termonad/IdMap.hs
@@ -1,0 +1,18 @@
+-- | Module    : Termonad.IdMap
+-- Description : A Map that keeps track of the ID of values
+-- Copyright   : (c) Dennis Gosnell, 2023
+-- License     : BSD3
+-- Stability   : experimental
+-- Portability : POSIX
+
+module Termonad.IdMap
+  ( IdMapKey
+  , IdMap
+  , emptyIdMap
+  , singletonIdMap
+  , insertIdMap
+  , lookupIdMap
+  , keysIdMap
+  ) where
+
+import Termonad.IdMap.Internal

--- a/src/Termonad/IdMap/Internal.hs
+++ b/src/Termonad/IdMap/Internal.hs
@@ -1,0 +1,80 @@
+-- | Module    : Termonad.IdMap
+-- Description : A Map that keeps track of the ID of values
+-- Copyright   : (c) Dennis Gosnell, 2023
+-- License     : BSD3
+-- Stability   : experimental
+-- Portability : POSIX
+
+module Termonad.IdMap.Internal where
+
+import Termonad.Prelude
+
+import Control.Lens (FoldableWithIndex, ifoldMap, Index, IxValue, Traversal', Ixed (ix))
+import qualified Data.Foldable as Foldable
+import Data.IntMap.Strict (IntMap)
+import qualified Data.IntMap.Strict as IntMap
+
+-- TODO: Write tests for this!
+
+newtype IdMapKey = IdMapKey { unIdMapKey :: Int }
+  deriving stock Show
+
+data IdMap a = IdMap
+  { idMap :: !(IntMap a)
+  , nextId :: !Int
+  }
+  deriving stock Show
+
+instance Functor IdMap where
+  fmap f IdMap{idMap, nextId} = IdMap { idMap = fmap f idMap, nextId }
+
+instance Foldable IdMap where
+  foldMap f m = Foldable.foldMap f $ idMap m
+
+instance FoldableWithIndex Int IdMap where
+  ifoldMap f m = ifoldMap f $ idMap m
+
+instance Traversable IdMap where
+  traverse f IdMap{idMap, nextId} =
+    fmap (\m -> IdMap { idMap = m, nextId }) (traverse f idMap)
+
+type instance Index (IdMap a) = IdMapKey
+type instance IxValue (IdMap a) = a
+
+instance Ixed (IdMap a) where
+  ix :: IdMapKey -> Traversal' (IdMap a) a
+  ix (IdMapKey i) f IdMap{idMap, nextId} =
+    case IntMap.lookup i idMap of
+      Just v -> fmap update (f v) -- f v <&> \v' -> IntMap.insert k v' m
+      Nothing -> pure IdMap{idMap, nextId}
+    where
+      update :: a -> IdMap a
+      update v' =
+        IdMap
+          { idMap = IntMap.adjust (const v') i idMap
+          , nextId
+          }
+
+initialId :: Int
+initialId = 0
+
+succId :: Int -> Int
+succId i = i + 1
+
+emptyIdMap :: IdMap a
+emptyIdMap = IdMap { idMap = mempty, nextId = 0 }
+
+insertIdMap :: a -> IdMap a -> (IdMapKey, IdMap a)
+insertIdMap a IdMap {idMap, nextId} =
+  let newMap = IntMap.insert nextId a idMap
+      newNextId = nextId + 1
+  in (IdMapKey nextId, IdMap { idMap = newMap, nextId = newNextId })
+
+singletonIdMap :: a -> (IdMapKey, IdMap a)
+singletonIdMap a = insertIdMap a emptyIdMap
+
+lookupIdMap :: IdMapKey -> IdMap a -> Maybe a
+lookupIdMap (IdMapKey k) IdMap {idMap} = IntMap.lookup k idMap
+
+keysIdMap :: IdMap a -> [IdMapKey]
+keysIdMap IdMap {idMap} = fmap IdMapKey $ IntMap.keys idMap

--- a/src/Termonad/Lenses.hs
+++ b/src/Termonad/Lenses.hs
@@ -29,12 +29,17 @@ $(makeLensesFor
  )
 
 $(makeLensesFor
+    [ ("tmWindowAppWin", "lensTMWindowAppWin")
+    , ("tmWindowNotebook", "lensTMWindowNotebook")
+    ]
+    ''TMWindow
+ )
+
+$(makeLensesFor
     [ ("tmStateApp", "lensTMStateApp")
-    , ("tmStateAppWin", "lensTMStateAppWin")
-    , ("tmStateNotebook", "lensTMStateNotebook")
     , ("tmStateFontDesc", "lensTMStateFontDesc")
     , ("tmStateConfig", "lensTMStateConfig")
-    , ("tmStateUserReqExit", "lensTMStateUserReqExit")
+    , ("tmStateWindows", "lensTMStateWindows")
     ]
     ''TMState'
  )

--- a/src/Termonad/PreferencesFile.hs
+++ b/src/Termonad/PreferencesFile.hs
@@ -9,17 +9,18 @@ import Data.Aeson (Result(..), fromJSON)
 #if MIN_VERSION_aeson(2, 0, 0)
 import qualified Data.Aeson.KeyMap as KeyMap
 #endif
+import qualified Data.ByteString as ByteString
 import qualified Data.HashMap.Strict as HashMap
+import Data.Text (pack)
 import Data.Yaml (ParseException, ToJSON (toJSON), decodeFileEither, encode, prettyPrintParseException)
 import Data.Yaml.Aeson (Value(..))
-
 import System.Directory
   ( XdgDirectory(XdgConfig)
   , createDirectoryIfMissing
   , doesFileExist
   , getXdgDirectory
   )
-
+import System.FilePath ((</>))
 import Termonad.Types
   ( ConfigOptions
   , TMConfig(TMConfig, hooks, options)
@@ -184,7 +185,7 @@ writePreferencesFile confFile options = do
         "# The settings in this file will be ignored if you have a\n" <>
         "# termonad.hs file in this same directory.\n\n" <>
         yaml
-  writeFile confFile yamlWithComment
+  ByteString.writeFile confFile yamlWithComment
 
 -- | Save the configuration to the preferences file
 -- @~\/.config\/termonad\/termonad.yaml@

--- a/src/Termonad/Prelude.hs
+++ b/src/Termonad/Prelude.hs
@@ -1,17 +1,42 @@
+
+-- | This is a basic prelude-like module that adds a bunch of common datatypes
+-- and functions to the 'Prelude'.
+
 module Termonad.Prelude
   ( module X
   , hPutStrLn
   , whenJust
+  , stderr
+  , tshow
   ) where
 
+import Control.Concurrent.MVar as X (MVar, modifyMVar, modifyMVar_, newMVar, readMVar, withMVar)
+import Control.Exception as X (IOException, try)
 import Control.Lens as X ((&))
+import Control.Monad as X (join, unless, void, when, (<=<))
+import Control.Monad.IO.Class as X
+import Control.Monad.Trans.Class as X (lift)
 import Control.Monad.Trans.Maybe as X (MaybeT(MaybeT), runMaybeT)
-import ClassyPrelude as X
+import Data.ByteString as X (ByteString)
+import Data.Function as X (on)
+import Data.Functor as X (($>))
+import Data.Int as X (Int32)
+import Data.Maybe as X (catMaybes, fromMaybe)
 import Data.Proxy as X
+import Data.String as X (IsString)
+import Data.Text as X (Text)
+import Data.Text (pack)
 import qualified Data.Text.IO as TextIO
+import Data.Word as X (Word8, Word32)
+import GHC.Generics as X (Generic)
+import Prelude as X
+import System.IO (Handle, stderr)
 
 whenJust :: Monoid m => Maybe a -> (a -> m) -> m
 whenJust = flip foldMap
 
 hPutStrLn :: MonadIO m => Handle -> Text -> m ()
 hPutStrLn hndl = liftIO . TextIO.hPutStrLn hndl
+
+tshow :: Show a => a -> Text
+tshow = pack . show

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -159,11 +159,13 @@ focusTerm i mvarTMState tmWinId = do
 altNumSwitchTerm :: Int -> TMState -> TMWindowId -> IO ()
 altNumSwitchTerm = focusTerm
 
+-- | Change focus to the next tab.
 termNextPage :: TMState -> TMWindowId -> IO ()
 termNextPage mvarTMState tmWinId = do
   note <- getNotebookFromTMState mvarTMState tmWinId
   notebookNextPage note
 
+-- | Change focus to the previous tab.
 termPrevPage :: TMState -> TMWindowId -> IO ()
 termPrevPage mvarTMState tmWinId = do
   note <- getNotebookFromTMState mvarTMState tmWinId

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -4,9 +4,13 @@ module Termonad.Term where
 
 import Termonad.Prelude
 
-import Control.Lens ((^.), (.~), set, to)
+import Control.Lens ((^.), ix, set)
+import Data.Coerce (coerce)
 import Data.Colour.SRGB (Colour, RGB(RGB), toSRGB)
 import Data.FocusList (appendFL, deleteFL, getFocusItemFL)
+import Data.GI.Base (toManagedPtr)
+import Data.Text (pack)
+import qualified Data.Text as Text
 import GI.Gdk
   ( Event (Event)
   , EventButton
@@ -109,7 +113,7 @@ import GI.Vte
   )
 import System.Directory (getSymbolicLinkTarget)
 import System.Environment (lookupEnv)
-
+import System.FilePath ((</>))
 import Termonad.Gtk (terminalSetEnableSixelIfExists)
 import Termonad.Lenses
   ( lensConfirmExit
@@ -122,9 +126,9 @@ import Termonad.Lenses
   , lensTMNotebookTabs
   , lensTMStateApp
   , lensTMStateConfig
-  , lensTMStateNotebook
-  , lensTerm
+  , lensTerm, lensTMStateWindows, lensTMWindowNotebook
   )
+import Termonad.Pcre (pcre2Multiline)
 import Termonad.Types
   ( ConfigHooks(createTermHook)
   , ConfigOptions(scrollbackLen, wordCharExceptions, cursorBlinkMode, boldIsBright, enableSixel, allowBold)
@@ -134,8 +138,9 @@ import Termonad.Types
   , TMNotebook
   , TMNotebookTab
   , TMState
-  , TMState'(TMState, tmStateAppWin, tmStateConfig, tmStateFontDesc, tmStateNotebook)
+  , TMState'(TMState, tmStateConfig, tmStateFontDesc)
   , TMTerm
+  , TMWindow
   , assertInvariantTMState
   , createTMNotebookTab
   , newTMTerm
@@ -143,48 +148,44 @@ import Termonad.Types
   , tmNotebook
   , tmNotebookTabTerm
   , tmNotebookTabTermContainer
-  , tmNotebookTabs
+  , tmNotebookTabs, TMWindowId, tmStateWindows, getTMWindowFromWins, tmWindowNotebook, getTMWindowFromTMState, getNotebookFromTMState, getTMNotebookFromTMState, getTMNotebookFromTMState', tmWindowAppWin
   )
-import Data.Coerce (coerce)
-import Data.GI.Base (toManagedPtr)
-import Termonad.Pcre (pcre2Multiline)
 
-focusTerm :: Int -> TMState -> IO ()
-focusTerm i mvarTMState = do
-  note <- tmNotebook . tmStateNotebook <$> readMVar mvarTMState
+focusTerm :: Int -> TMState -> TMWindowId -> IO ()
+focusTerm i mvarTMState tmWinId = do
+  note <- getNotebookFromTMState mvarTMState tmWinId
   notebookSetCurrentPage note (fromIntegral i)
 
-altNumSwitchTerm :: Int -> TMState -> IO ()
+altNumSwitchTerm :: Int -> TMState -> TMWindowId -> IO ()
 altNumSwitchTerm = focusTerm
 
-termNextPage :: TMState -> IO ()
-termNextPage mvarTMState = do
-  note <- tmNotebook . tmStateNotebook <$> readMVar mvarTMState
+termNextPage :: TMState -> TMWindowId -> IO ()
+termNextPage mvarTMState tmWinId = do
+  note <- getNotebookFromTMState mvarTMState tmWinId
   notebookNextPage note
 
-termPrevPage :: TMState -> IO ()
-termPrevPage mvarTMState = do
-  note <- tmNotebook . tmStateNotebook <$> readMVar mvarTMState
+termPrevPage :: TMState -> TMWindowId -> IO ()
+termPrevPage mvarTMState tmWinId = do
+  note <- getNotebookFromTMState mvarTMState tmWinId
   notebookPrevPage note
 
-termExitFocused :: TMState -> IO ()
-termExitFocused mvarTMState = do
-  tmState <- readMVar mvarTMState
-  let maybeTab =
-        tmState ^. lensTMStateNotebook . lensTMNotebookTabs . to getFocusItemFL
+termExitFocused :: TMState -> TMWindowId -> IO ()
+termExitFocused mvarTMState tmWinId = do
+  note <- getTMNotebookFromTMState mvarTMState tmWinId
+  let maybeTab = getFocusItemFL $ tmNotebookTabs note
   case maybeTab of
     Nothing -> pure ()
-    Just tab -> termClose tab mvarTMState
+    Just tab -> termClose tab mvarTMState tmWinId
 
-termClose :: TMNotebookTab -> TMState -> IO ()
-termClose tab mvarTMState = do
+termClose :: TMNotebookTab -> TMState -> TMWindowId -> IO ()
+termClose tab mvarTMState tmWindowId = do
   tmState <- readMVar mvarTMState
   let confirm = tmState ^. lensTMStateConfig . lensOptions . lensConfirmExit
       close = if confirm then termExitWithConfirmation else termExit
-  close tab mvarTMState
+  close tab mvarTMState tmWindowId
 
-termExitWithConfirmation :: TMNotebookTab -> TMState -> IO ()
-termExitWithConfirmation tab mvarTMState = do
+termExitWithConfirmation :: TMNotebookTab -> TMState -> TMWindowId -> IO ()
+termExitWithConfirmation tab mvarTMState tmWinId = do
   tmState <- readMVar mvarTMState
   let app = tmState ^. lensTMStateApp
   win <- applicationGetActiveWindow app
@@ -208,30 +209,34 @@ termExitWithConfirmation tab mvarTMState = do
   res <- dialogRun dialog
   widgetDestroy dialog
   case toEnum (fromIntegral res) of
-    ResponseTypeYes -> termExit tab mvarTMState
+    ResponseTypeYes -> termExit tab mvarTMState tmWinId
     _ -> pure ()
 
-termExit :: TMNotebookTab -> TMState -> IO ()
-termExit tab mvarTMState = do
+termExit :: TMNotebookTab -> TMState -> TMWindowId -> IO ()
+termExit tab mvarTMState tmWinId = do
   detachTabAction <-
     modifyMVar mvarTMState $ \tmState -> do
-      let notebook = tmStateNotebook tmState
+      tmNote <- getTMNotebookFromTMState' tmState tmWinId
+      let detachTabAction :: IO ()
           detachTabAction =
             notebookDetachTab
-              (tmNotebook notebook)
+              (tmNotebook tmNote)
               (tmNotebookTabTermContainer tab)
-      let newTabs = deleteFL tab (tmNotebookTabs notebook)
-      let newTMState =
-            set (lensTMStateNotebook . lensTMNotebookTabs) newTabs tmState
+          newTabs = deleteFL tab (tmNotebookTabs tmNote)
+          newTMState =
+            set
+              (lensTMStateWindows . ix tmWinId . lensTMWindowNotebook . lensTMNotebookTabs)
+              newTabs
+              tmState
       pure (newTMState, detachTabAction)
   detachTabAction
-  relabelTabs mvarTMState
+  tmWin <- getTMWindowFromTMState mvarTMState tmWinId
+  relabelTabs (tmWindowNotebook tmWin)
 
-relabelTabs :: TMState -> IO ()
-relabelTabs mvarTMState = do
-  TMState{tmStateNotebook} <- readMVar mvarTMState
-  let notebook = tmNotebook tmStateNotebook
-      tabFocusList = tmNotebookTabs tmStateNotebook
+relabelTabs :: TMNotebook -> IO ()
+relabelTabs tmNote = do
+  let notebook = tmNotebook tmNote
+      tabFocusList = tmNotebookTabs tmNote
   foldMap (go notebook) tabFocusList
   where
     go :: Notebook -> TMNotebookTab -> IO ()
@@ -411,12 +416,13 @@ launchShell vteTerm maybeCurrDir = do
 -- | Add a page to the notebook and switch to it.
 addPage
   :: TMState
+  -> TMWindowId
   -> TMNotebookTab
   -> Box
   -- ^ The GTK Object holding the label we want to show for the tab of the
   -- newly created page of the notebook.
   -> IO ()
-addPage mvarTMState notebookTab tabLabelBox = do
+addPage mvarTMState tmWinId notebookTab tabLabelBox = do
   -- Append a new notebook page and update the TMState to reflect this.
   (note, pageIndex) <- modifyMVar mvarTMState appendNotebookPage
 
@@ -425,8 +431,8 @@ addPage mvarTMState notebookTab tabLabelBox = do
   where
     appendNotebookPage :: TMState' -> IO (TMState', (Notebook, Int32))
     appendNotebookPage tmState = do
-      let notebook = tmStateNotebook tmState
-          note = tmNotebook notebook
+      notebook <- getTMNotebookFromTMState' tmState tmWinId
+      let note = tmNotebook notebook
           tabs = tmNotebookTabs notebook
           scrolledWin = tmNotebookTabTermContainer notebookTab
       pageIndex <- notebookAppendPage note scrolledWin (Just tabLabelBox)
@@ -434,7 +440,10 @@ addPage mvarTMState notebookTab tabLabelBox = do
       setShowTabs (tmState ^. lensTMStateConfig) note
       let newTabs = appendFL tabs notebookTab
           newTMState =
-            tmState & lensTMStateNotebook . lensTMNotebookTabs .~ newTabs
+            set
+              (lensTMStateWindows . ix tmWinId . lensTMWindowNotebook . lensTMNotebookTabs)
+              newTabs
+              tmState
       pure (newTMState, (note, pageIndex))
 
 -- | Set the keyboard focus on a vte terminal
@@ -445,17 +454,23 @@ setFocusOn tmStateAppWin vteTerm = do
 
 -- | Create a new 'TMTerm', setting it up and adding it to the GTKNotebook.
 createTerm
-  :: (TMState -> EventKey -> IO Bool)
+  :: (TMState -> TMWindowId -> EventKey -> IO Bool)
   -- ^ Funtion for handling key presses on the terminal.
   -> TMState
+  -> TMWindowId
   -> IO TMTerm
-createTerm handleKeyPress mvarTMState = do
+createTerm handleKeyPress mvarTMState tmWinId = do
   -- Check preconditions
   assertInvariantTMState mvarTMState
 
   -- Read needed data in TMVar
-  TMState{tmStateAppWin, tmStateFontDesc, tmStateConfig, tmStateNotebook=currNote} <-
+  -- TMState{tmStateAppWin, tmStateFontDesc, tmStateConfig, tmStateNotebook=currNote} <-
+  --   readMVar mvarTMState
+  TMState{tmStateFontDesc, tmStateConfig, tmStateWindows} <-
     readMVar mvarTMState
+  tmWin <- getTMWindowFromWins tmStateWindows tmWinId
+  let appWin = tmWindowAppWin tmWin
+      currNote = tmWindowNotebook tmWin
 
   -- Create a new terminal and launch a shell in it
   vteTerm <- createAndInitVteTerm tmStateFontDesc (options tmStateConfig)
@@ -474,7 +489,7 @@ createTerm handleKeyPress mvarTMState = do
   let notebookTab = createTMNotebookTab tabLabel scrolledWin tmTerm
 
   -- Add the new notebooktab to the notebook.
-  addPage mvarTMState notebookTab tabLabelBox
+  addPage mvarTMState tmWinId notebookTab tabLabelBox
 
   -- Setup the initial label for the notebook tab.  This needs to happen
   -- after we add the new page to the notebook, so that the page can get labelled
@@ -482,15 +497,13 @@ createTerm handleKeyPress mvarTMState = do
   relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
 
   -- Connect callbacks
-  void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState
+  void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState tmWinId
   void $ onTerminalWindowTitleChanged vteTerm $ do
-    TMState{tmStateNotebook} <- readMVar mvarTMState
-    let notebook = tmNotebook tmStateNotebook
-    relabelTab notebook tabLabel scrolledWin vteTerm
-  void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState
-  void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState
-  void $ onWidgetButtonPressEvent vteTerm $ handleMousePress tmStateAppWin vteTerm
-  void $ onTerminalChildExited vteTerm $ \_ -> termExit notebookTab mvarTMState
+    relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
+  void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState tmWinId
+  void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState tmWinId
+  void $ onWidgetButtonPressEvent vteTerm $ handleMousePress appWin vteTerm
+  void $ onTerminalChildExited vteTerm $ \_ -> termExit notebookTab mvarTMState tmWinId
 
   -- Underline URLs so that the user can see they are right-clickable.
   --
@@ -506,11 +519,11 @@ createTerm handleKeyPress mvarTMState = do
         "(?:http(s)?:\\/\\/)[\\w.-]+(?:\\.[\\w\\.-]+)+[\\w\\-\\._~:/?#[\\]@!\\$&'\\(\\)\\*\\+,;=.]+"
   -- We must set the pcre2Multiline option, otherwise VTE prints a warning.
   let pcreFlags = fromIntegral pcre2Multiline
-  regex <- regexNewForMatch regexPat (fromIntegral $ length regexPat) pcreFlags
+  regex <- regexNewForMatch regexPat (fromIntegral $ Text.length regexPat) pcreFlags
   void $ terminalMatchAddRegex vteTerm regex 0
 
   -- Put the keyboard focus on the term
-  setFocusOn tmStateAppWin vteTerm
+  setFocusOn appWin vteTerm
 
   -- Make sure the state is still right
   assertInvariantTMState mvarTMState

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -109,10 +109,10 @@ instance Show TMNotebook where
 
 data TMState' = TMState
   { tmStateApp :: !Application
+  , tmStateConfig :: !TMConfig
+  , tmStateFontDesc :: !FontDescription
   , tmStateAppWin :: !ApplicationWindow
   , tmStateNotebook :: !TMNotebook
-  , tmStateFontDesc :: !FontDescription
-  , tmStateConfig :: !TMConfig
   }
 
 instance Show TMState' where
@@ -123,17 +123,17 @@ instance Show TMState' where
       showString "tmStateApp = " .
       showString "(GI.GTK.Application)" .
       showString ", " .
+      showString "tmStateConfig = " .
+      showsPrec (d + 1) tmStateConfig .
+      showString ", " .
+      showString "tmStateFontDesc = " .
+      showString "(GI.Pango.FontDescription)" .
+      showString ", " .
       showString "tmStateAppWin = " .
       showString "(GI.GTK.ApplicationWindow)" .
       showString ", " .
       showString "tmStateNotebook = " .
       showsPrec (d + 1) tmStateNotebook .
-      showString ", " .
-      showString "tmStateFontDesc = " .
-      showString "(GI.Pango.FontDescription)" .
-      showString ", " .
-      showString "tmStateConfig = " .
-      showsPrec (d + 1) tmStateConfig .
       showString "}"
 
 type TMState = MVar TMState'

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -4,8 +4,10 @@ module Termonad.Types where
 
 import Termonad.Prelude
 
+import Control.Lens (ifoldMap)
 import Control.Monad.Fail (fail)
-import Data.FocusList (FocusList, emptyFL, singletonFL, getFocusItemFL, lengthFL)
+import Data.FocusList (FocusList, emptyFL, getFocusItemFL, lengthFL)
+import Data.Foldable (toList)
 import Data.Unique (Unique, hashUnique, newUnique)
 import Data.Yaml
   ( FromJSON(parseJSON)
@@ -27,10 +29,10 @@ import GI.Gtk
   )
 import GI.Pango (FontDescription)
 import GI.Vte (Terminal, CursorBlinkMode(..))
+import Termonad.Gtk (widgetEq)
+import Termonad.IdMap (IdMap, IdMapKey, singletonIdMap, lookupIdMap)
 import Text.Pretty.Simple (pPrint)
 import Text.Show (ShowS, showParen, showString)
-
-import Termonad.Gtk (widgetEq)
 
 -- | A wrapper around a VTE 'Terminal'.  This also stores the process ID of the
 -- process running on this terminal, as well as a 'Unique' that can be used for
@@ -107,12 +109,71 @@ instance Show TMNotebook where
       showsPrec (d + 1) tmNotebookTabs .
       showString "}"
 
+getNotebookFromTMState :: TMState -> TMWindowId -> IO Notebook
+getNotebookFromTMState mvarTMState tmWinId = do
+  tmNote <- getTMNotebookFromTMState mvarTMState tmWinId
+  pure $ tmNotebook tmNote
+
+getNotebookFromTMState' :: TMState' -> TMWindowId -> IO Notebook
+getNotebookFromTMState' tmState tmWinId = do
+  tmNote <- getTMNotebookFromTMState' tmState tmWinId
+  pure $ tmNotebook tmNote
+
+getTMNotebookFromTMState :: TMState -> TMWindowId -> IO TMNotebook
+getTMNotebookFromTMState mvarTMState tmWinId = do
+  tmWin <- getTMWindowFromTMState mvarTMState tmWinId
+  pure $ tmWindowNotebook tmWin
+
+getTMNotebookFromTMState' :: TMState' -> TMWindowId -> IO TMNotebook
+getTMNotebookFromTMState' tmState tmWinId = do
+  tmWin <- getTMWindowFromTMState' tmState tmWinId
+  pure $ tmWindowNotebook tmWin
+
+data TMWindow = TMWindow
+  { tmWindowAppWin :: !ApplicationWindow
+  , tmWindowNotebook :: !TMNotebook
+  }
+
+instance Show TMWindow where
+  showsPrec :: Int -> TMWindow -> ShowS
+  showsPrec d TMWindow{..} =
+    showParen (d > 10) $
+      showString "TMWindow {" .
+      showString "tmWindowAppWin = " .
+      showString "(GI.GTK.ApplicationWindow)" .
+      showString ", " .
+      showString "tmWindowNotebook = " .
+      showsPrec (d + 1) tmWindowNotebook .
+      showString "}"
+
+type TMWindowId = IdMapKey
+
+-- | Get a given 'TMWindow' from a set of 'TMWindow's given a 'TMWindowId'.
+--
+-- This throws an error if the 'TMWindowId' can't be found within the 'IdMap'.
+getTMWindowFromWins :: IdMap TMWindow -> TMWindowId -> IO TMWindow
+getTMWindowFromWins tmWins tmWinId =
+  case lookupIdMap tmWinId tmWins of
+    Nothing -> error $ "getTMWindowFromWins: trying to get id " <> show tmWinId <> " from wins, but doesn't exist: " <> show tmWins
+    Just tmWin -> pure tmWin
+
+-- | Get a given 'TMWindow' froma a 'TMState' given a 'TMWindowId'.
+--
+-- This throws an error if the 'TMWindowId' can't be found within the 'TMState'.
+getTMWindowFromTMState :: TMState -> TMWindowId -> IO TMWindow
+getTMWindowFromTMState mvarTMState tmWinId = do
+  TMState{tmStateWindows} <- readMVar mvarTMState
+  getTMWindowFromWins tmStateWindows tmWinId
+
+getTMWindowFromTMState' :: TMState' -> TMWindowId -> IO TMWindow
+getTMWindowFromTMState' tmState tmWinId =
+  getTMWindowFromWins (tmStateWindows tmState) tmWinId
+
 data TMState' = TMState
   { tmStateApp :: !Application
   , tmStateConfig :: !TMConfig
   , tmStateFontDesc :: !FontDescription
-  , tmStateAppWin :: !ApplicationWindow
-  , tmStateNotebook :: !TMNotebook
+  , tmStateWindows :: !(IdMap TMWindow)
   }
 
 instance Show TMState' where
@@ -129,11 +190,8 @@ instance Show TMState' where
       showString "tmStateFontDesc = " .
       showString "(GI.Pango.FontDescription)" .
       showString ", " .
-      showString "tmStateAppWin = " .
-      showString "(GI.GTK.ApplicationWindow)" .
-      showString ", " .
-      showString "tmStateNotebook = " .
-      showsPrec (d + 1) tmStateNotebook .
+      showString "tmStateWindows = " .
+      showsPrec (d + 1) tmStateWindows .
       showString "}"
 
 type TMState = MVar TMState'
@@ -157,14 +215,14 @@ createTMTerm trm pd unq =
 newTMTerm :: Terminal -> Int -> IO TMTerm
 newTMTerm trm pd = createTMTerm trm pd <$> newUnique
 
-getFocusedTermFromState :: TMState -> IO (Maybe Terminal)
-getFocusedTermFromState mvarTMState =
+getFocusedTermFromState :: TMState -> TMWindowId -> IO (Maybe Terminal)
+getFocusedTermFromState mvarTMState tmWinId =
   withMVar mvarTMState go
   where
     go :: TMState' -> IO (Maybe Terminal)
     go tmState = do
-      let maybeNotebookTab =
-            getFocusItemFL $ tmNotebookTabs $ tmStateNotebook tmState
+      tmNote <- getTMNotebookFromTMState' tmState tmWinId
+      let maybeNotebookTab = getFocusItemFL $ tmNotebookTabs tmNote
       pure $ fmap (term . tmNotebookTabTerm) maybeNotebookTab
 
 createTMNotebookTab :: Label -> ScrolledWindow -> TMTerm -> TMNotebookTab
@@ -195,45 +253,27 @@ notebookToList notebook =
             Nothing -> pure acc
             Just notePage' -> unfoldHelper (index32 + 1) (acc ++ [notePage'])
 
-newTMState :: TMConfig -> Application -> ApplicationWindow -> TMNotebook -> FontDescription -> IO TMState
-newTMState tmConfig app appWin note fontDesc =
-  newMVar $
-    TMState
-      { tmStateApp = app
-      , tmStateAppWin = appWin
-      , tmStateNotebook = note
-      , tmStateFontDesc = fontDesc
-      , tmStateConfig = tmConfig
-      }
+createTMWindow :: ApplicationWindow -> TMNotebook -> TMWindow
+createTMWindow appwin notebook =
+  TMWindow
+    { tmWindowAppWin = appwin
+    , tmWindowNotebook = notebook
+    }
 
-newEmptyTMState :: TMConfig -> Application -> ApplicationWindow -> Notebook -> FontDescription -> IO TMState
-newEmptyTMState tmConfig app appWin note fontDesc =
-  newMVar $
-    TMState
-      { tmStateApp = app
-      , tmStateAppWin = appWin
-      , tmStateNotebook = createEmptyTMNotebook note
-      , tmStateFontDesc = fontDesc
-      , tmStateConfig = tmConfig
-      }
-
-newTMStateSingleTerm ::
-     TMConfig
-  -> Application
-  -> ApplicationWindow
-  -> Notebook
-  -> Label
-  -> ScrolledWindow
-  -> Terminal
-  -> Int
-  -> FontDescription
-  -> IO TMState
-newTMStateSingleTerm tmConfig app appWin note label scrollWin trm pd fontDesc = do
-  tmTerm <- newTMTerm trm pd
-  let tmNoteTab = createTMNotebookTab label scrollWin tmTerm
-      tabs = singletonFL tmNoteTab
-      tmNote = createTMNotebook note tabs
-  newTMState tmConfig app appWin tmNote fontDesc
+newEmptyTMState :: TMConfig -> Application -> ApplicationWindow -> Notebook -> FontDescription -> IO (TMState, TMWindowId)
+newEmptyTMState tmConfig app appWin note fontDesc = do
+  let tmnote = createEmptyTMNotebook note
+      tmwin = createTMWindow appWin tmnote
+      (tmwinId, tmwins) = singletonIdMap tmwin
+  tmState <-
+    newMVar $
+      TMState
+        { tmStateApp = app
+        , tmStateConfig = tmConfig
+        , tmStateFontDesc = fontDesc
+        , tmStateWindows = tmwins
+        }
+  pure (tmState, tmwinId)
 
 ------------
 -- Config --
@@ -579,32 +619,36 @@ data TabsDoNotMatch
                                 -- the actual GTK 'Notebook' and the 'FocusList'.
   deriving (Show)
 
-data TMStateInvariantErr
+-- | An invariant error on a given 'TMWindow'.
+data TMWinInvariantErr
   = FocusNotSame FocusNotSameErr Int
   | TabsDoNotMatch TabsDoNotMatch
   deriving Show
 
--- | Gather up the invariants for 'TMState' and return them as a list.
---
--- If no invariants have been violated, then this function should return an
--- empty list.
-invariantTMState' :: TMState' -> IO [TMStateInvariantErr]
-invariantTMState' tmState =
+-- | An invariant error on a whole 'TMState'.
+data TMStateInvariantErr
+  = TMWinInvariantErr Int TMWinInvariantErr
+    -- ^ An invariant error with a given 'TMWindow'.  The 'Int' indicates
+    -- which window it is as an index into 'tmStateWindows'.
+  deriving Show
+
+invariantTMWindow :: TMWindow -> IO [TMWinInvariantErr]
+invariantTMWindow tmWin =
   runInvariants
     [ invariantFocusSame
     , invariantTMTabLength
     , invariantTabsAllMatch
     ]
   where
-    runInvariants :: [IO (Maybe TMStateInvariantErr)] -> IO [TMStateInvariantErr]
+    runInvariants :: [IO (Maybe TMWinInvariantErr)] -> IO [TMWinInvariantErr]
     runInvariants = fmap catMaybes . sequence
 
-    invariantFocusSame :: IO (Maybe TMStateInvariantErr)
+    invariantFocusSame :: IO (Maybe TMWinInvariantErr)
     invariantFocusSame = do
-      let tmNote = tmNotebook $ tmStateNotebook tmState
+      let tmNote = tmNotebook $ tmWindowNotebook tmWin
       index32 <- notebookGetCurrentPage tmNote
       maybeWidgetFromNote <- notebookGetNthPage tmNote index32
-      let focusList = tmNotebookTabs $ tmStateNotebook tmState
+      let focusList = tmNotebookTabs $ tmWindowNotebook tmWin
           maybeScrollWinFromFL =
             tmNotebookTabTermContainer <$> getFocusItemFL focusList
           idx = fromIntegral index32
@@ -627,12 +671,12 @@ invariantTMState' tmState =
                 Just $
                   FocusNotSame NotebookTabWidgetDiffersFromFocusListFocus idx
 
-    invariantTMTabLength :: IO (Maybe TMStateInvariantErr)
+    invariantTMTabLength :: IO (Maybe TMWinInvariantErr)
     invariantTMTabLength = do
-      let tmNote = tmNotebook $ tmStateNotebook tmState
+      let tmNote = tmNotebook $ tmWindowNotebook tmWin
       noteLength32 <- notebookGetNPages tmNote
       let noteLength = fromIntegral noteLength32
-          focusListLength = lengthFL $ tmNotebookTabs $ tmStateNotebook tmState
+          focusListLength = lengthFL $ tmNotebookTabs $ tmWindowNotebook tmWin
           lengthEqual = focusListLength == noteLength
       if lengthEqual
         then pure Nothing
@@ -642,10 +686,10 @@ invariantTMState' tmState =
                  TabLengthsDifferent noteLength focusListLength
 
     -- Turns a FocusList and Notebook into two lists of widgets and compares each widget for equality
-    invariantTabsAllMatch :: IO (Maybe TMStateInvariantErr)
+    invariantTabsAllMatch :: IO (Maybe TMWinInvariantErr)
     invariantTabsAllMatch = do
-      let tmNote = tmNotebook $ tmStateNotebook tmState
-          focusList = tmNotebookTabs $ tmStateNotebook tmState
+      let tmNote = tmNotebook $ tmWindowNotebook tmWin
+          focusList = tmNotebookTabs $ tmWindowNotebook tmWin
           flList = tmNotebookTabTermContainer <$> toList focusList
       noteList <- notebookToList tmNote
       tabsMatch noteList flList
@@ -655,15 +699,29 @@ invariantTMState' tmState =
            . (IsWidget a, IsWidget b)
           => [a]
           -> [b]
-          -> IO (Maybe TMStateInvariantErr)
+          -> IO (Maybe TMWinInvariantErr)
         tabsMatch xs ys = foldr go (pure Nothing) (zip3 xs ys [0..])
           where
-            go :: (a, b, Int) -> IO (Maybe TMStateInvariantErr) -> IO (Maybe TMStateInvariantErr)
+            go :: (a, b, Int) -> IO (Maybe TMWinInvariantErr) -> IO (Maybe TMWinInvariantErr)
             go (x, y, i) acc = do
               isEq <- widgetEq x y
               if isEq
                 then acc
                 else pure . Just $ TabsDoNotMatch (TabAtIndexDifferent i)
+
+-- | Gather up the invariants for 'TMState' and return them as a list.
+--
+-- If no invariants have been violated, then this function should return an
+-- empty list.
+invariantTMState' :: TMState' -> IO [TMStateInvariantErr]
+invariantTMState' tmState = do
+  let tmWindows = tmStateWindows tmState
+  ifoldMap go tmWindows
+  where
+    go :: Int -> TMWindow -> IO [TMStateInvariantErr]
+    go idx tmWin = do
+      tmWinErrs <- invariantTMWindow tmWin
+      pure $ fmap (TMWinInvariantErr idx) tmWinErrs
 
 -- | Check the invariants for 'TMState', and call 'fail' if we find that they
 -- have been violated.

--- a/src/Termonad/XML.hs
+++ b/src/Termonad/XML.hs
@@ -68,7 +68,7 @@ menuDoc =
             </item>
             <item>
               <attribute name="label" translatable="yes">_Quit</attribute>
-              <attribute name="action">win.quit</attribute>
+              <attribute name="action">app.quit</attribute>
             </item>
           </section>
         </submenu>

--- a/src/Termonad/XML.hs
+++ b/src/Termonad/XML.hs
@@ -7,6 +7,8 @@ import Termonad.Prelude
 
 import Data.Default (def)
 import Data.FileEmbed (embedFile)
+import Data.Text.Encoding (decodeUtf8)
+import qualified Data.Text.Lazy as LText
 import Text.XML (renderText)
 import Text.XML.QQ (Document, xmlRaw)
 
@@ -23,7 +25,7 @@ interfaceDoc =
     <interface>
       <!-- interface-requires gtk+ 3.8 -->
       <object id="appWin" class="GtkApplicationWindow">
-        <property name="title" translatable="yes">Example Application</property>
+        <property name="title" translatable="yes">Termonad</property>
         <property name="default-width">600</property>
         <property name="default-height">400</property>
         <child>
@@ -42,7 +44,7 @@ interfaceDoc =
    |]
 
 interfaceText :: Text
-interfaceText = toStrict $ renderText def interfaceDoc
+interfaceText = LText.toStrict $ renderText def interfaceDoc
 
 menuDoc :: Document
 menuDoc =
@@ -56,17 +58,17 @@ menuDoc =
           <section>
             <item>
               <attribute name="label" translatable="yes">New _Tab</attribute>
-              <attribute name="action">app.newtab</attribute>
+              <attribute name="action">win.newtab</attribute>
             </item>
           </section>
           <section>
             <item>
               <attribute name="label" translatable="yes">_Close Tab</attribute>
-              <attribute name="action">app.closetab</attribute>
+              <attribute name="action">win.closetab</attribute>
             </item>
             <item>
               <attribute name="label" translatable="yes">_Quit</attribute>
-              <attribute name="action">app.quit</attribute>
+              <attribute name="action">win.quit</attribute>
             </item>
           </section>
         </submenu>
@@ -74,11 +76,11 @@ menuDoc =
           <attribute name="label" translatable="yes">Edit</attribute>
           <item>
             <attribute name="label" translatable="yes">_Copy</attribute>
-            <attribute name="action">app.copy</attribute>
+            <attribute name="action">win.copy</attribute>
           </item>
           <item>
             <attribute name="label" translatable="yes">_Paste</attribute>
-            <attribute name="action">app.paste</attribute>
+            <attribute name="action">win.paste</attribute>
           </item>
           <item>
             <attribute name="label" translatable="yes">_Preferences</attribute>
@@ -100,15 +102,15 @@ menuDoc =
           <attribute name="label" translatable="yes">Search</attribute>
           <item>
             <attribute name="label" translatable="yes">_Find...</attribute>
-            <attribute name="action">app.find</attribute>
+            <attribute name="action">win.find</attribute>
           </item>
           <item>
             <attribute name="label" translatable="yes">Find Above</attribute>
-            <attribute name="action">app.findabove</attribute>
+            <attribute name="action">win.findabove</attribute>
           </item>
           <item>
             <attribute name="label" translatable="yes">Find Below</attribute>
-            <attribute name="action">app.findbelow</attribute>
+            <attribute name="action">win.findbelow</attribute>
           </item>
         </submenu>
         <submenu>
@@ -123,7 +125,7 @@ menuDoc =
    |]
 
 menuText :: Text
-menuText = toStrict $ renderText def menuDoc
+menuText = LText.toStrict $ renderText def menuDoc
 
 aboutDoc :: Document
 aboutDoc =
@@ -201,7 +203,7 @@ aboutDoc =
    |]
 
 aboutText :: Text
-aboutText = toStrict $ renderText def aboutDoc
+aboutText = LText.toStrict $ renderText def aboutDoc
 
 closeTabDoc :: Document
 closeTabDoc =
@@ -258,7 +260,7 @@ closeTabDoc =
    |]
 
 closeTabText :: Text
-closeTabText = toStrict $ renderText def closeTabDoc
+closeTabText = LText.toStrict $ renderText def closeTabDoc
 
 preferencesText :: Text
 preferencesText = decodeUtf8 $(embedFile "glade/preferences.glade")

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -63,6 +63,8 @@ library
                      , Termonad.Config
                      , Termonad.Config.Colour
                      , Termonad.Gtk
+                     , Termonad.IdMap
+                     , Termonad.IdMap.Internal
                      , Termonad.Keys
                      , Termonad.Lenses
                      , Termonad.Pcre
@@ -74,7 +76,7 @@ library
   other-modules:       Paths_termonad
   build-depends:       base >= 4.13 && < 5
                      , aeson
-                     , classy-prelude
+                     , bytestring
                      , colour
                      , containers
                      , data-default


### PR DESCRIPTION
This is the initial PR for adding support for controlling multiple Windows within a single Termonad Application.

This PR just contains a large refactoring of the `TMState` data type, which adds the ability to track multiple GTK Windows, in the data type `TMWindow`.

However, there is no actual code supporting the creation of multiple windows, so this PR is mostly just a reorganization.  It should not have changed any actual functionality in Termonad.

Related to #6
