### PR TITLE
Split Window-specific functions out of Termonad.App into new Termonad.Window module

### DIFF
--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -622,13 +622,6 @@ findBelow mvarTMState tmWinId = do
       -- putStrLn $ "was match found: " <> tshow matchFound
       pure ()
 
-setShowMenuBar :: Application -> Bool -> IO ()
-setShowMenuBar app visible = do
-  void $ runMaybeT $ do
-    win <- MaybeT $ applicationGetActiveWindow app
-    appWin <- MaybeT $ castTo ApplicationWindow win
-    lift $ applicationWindowSetShowMenubar appWin visible
-
 appStartup :: Application -> IO ()
 appStartup _app = pure ()
 

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -29,7 +29,6 @@ import GI.Gtk
   , ResponseType(ResponseTypeNo, ResponseTypeYes)
   , ScrolledWindow(ScrolledWindow)
   , pattern STYLE_PROVIDER_PRIORITY_APPLICATION
-  , aboutDialogNew
   , applicationAddWindow
   , applicationGetActiveWindow
   , applicationSetAccelsForAction
@@ -121,7 +120,7 @@ import Termonad.Types
   , tmNotebookTabs
   )
 import Termonad.XML (interfaceText, menuText)
-import Termonad.Window (doFind, findAbove, findBelow)
+import Termonad.Window (doFind, findAbove, findBelow, showAboutDialog)
 
 setupScreenStyle :: IO ()
 setupScreenStyle = do
@@ -443,7 +442,7 @@ setupTermonad tmConfig app win builder = do
   applicationSetAccelsForAction app "win.findbelow" ["<Shift><Ctrl>I"]
 
   aboutAction <- simpleActionNew "about" Nothing
-  void $ onSimpleActionActivate aboutAction $ \_ -> showAboutDialog app
+  void $ onSimpleActionActivate aboutAction $ \_ -> showAboutDialog win
   actionMapAddAction app aboutAction
 
   menuBuilder <- builderNewFromString menuText $ fromIntegral (Text.length menuText)
@@ -484,14 +483,6 @@ appActivate tmConfig app = do
   applicationAddWindow app appWin
   setupTermonad tmConfig app appWin uiBuilder
   windowPresent appWin
-
-showAboutDialog :: Application -> IO ()
-showAboutDialog app = do
-  win <- applicationGetActiveWindow app
-  aboutDialog <- aboutDialogNew
-  windowSetTransientFor aboutDialog win
-  void $ dialogRun aboutDialog
-  widgetDestroy aboutDialog
 
 appStartup :: Application -> IO ()
 appStartup _app = pure ()

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -4,13 +4,12 @@ module Termonad.App where
 
 import Termonad.Prelude
 
-import Control.Lens ((^.), (^..), set, view, ix)
+import Control.Lens ((^.), set, ix)
 import Data.FileEmbed (embedFile)
-import Data.FocusList (focusList, updateFocusFL)
-import Data.Sequence (findIndexR)
+import Data.FocusList (updateFocusFL)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
-import GI.Gdk (castTo, managedForeignPtr, screenGetDefault)
+import GI.Gdk (screenGetDefault)
 import GI.Gio
   ( ApplicationFlags(ApplicationFlagsFlagsNone)
   , MenuModel(MenuModel)
@@ -27,7 +26,6 @@ import GI.Gtk
   , ApplicationWindow(ApplicationWindow)
   , Box(Box)
   , ResponseType(ResponseTypeNo, ResponseTypeYes)
-  , ScrolledWindow(ScrolledWindow)
   , pattern STYLE_PROVIDER_PRIORITY_APPLICATION
   , applicationAddWindow
   , applicationGetActiveWindow
@@ -65,62 +63,44 @@ import GI.Gtk
   , windowSetTransientFor
   )
 import qualified GI.Gtk as Gtk
-import GI.Pango
-  ( FontDescription
-  , pattern SCALE
-  , fontDescriptionNew
-  , fontDescriptionSetFamily
-  , fontDescriptionSetSize
-  , fontDescriptionSetAbsoluteSize
-  )
 import GI.Vte
   ( terminalCopyClipboard
   , terminalPasteClipboard
-  , terminalSetFont
   )
 import Termonad.Gtk (appNew, imgToPixbuf, objFromBuildUnsafe)
 import Termonad.Keys (handleKeyPress)
 import Termonad.Lenses
   ( lensConfirmExit
-  , lensFontConfig
   , lensOptions
   , lensShowMenu
   , lensTMNotebookTabs
   , lensTMNotebookTabTerm
   , lensTMStateApp
   , lensTMStateConfig
-  , lensTMStateFontDesc
   , lensTerm
   , lensTMStateWindows, lensTMWindowNotebook
   )
 import Termonad.Preferences (showPreferencesDialog)
 import Termonad.Term
   ( createTerm
-  , relabelTabs
   , termNextPage
   , termPrevPage
   , termExitFocused
   , setShowTabs
   )
 import Termonad.Types
-  ( FontConfig(..)
-  , FontSize(FontSizePoints, FontSizeUnits)
-  , TMConfig
-  , TMNotebookTab
+  ( TMConfig
   , TMState
   , TMState'
-  , TMWindowId
-  , fontSizeFromFontDescription
+  , createFontDescFromConfig
   , getFocusedTermFromState
-  , getTMNotebookFromTMState
   , getTMNotebookFromTMState'
   , modFontSize
   , newEmptyTMState
-  , tmNotebookTabTermContainer
-  , tmNotebookTabs, createFontDescFromConfig
+  , tmNotebookTabs
   )
 import Termonad.XML (interfaceText, menuText)
-import Termonad.Window (doFind, findAbove, findBelow, showAboutDialog, updateFLTabPos, notebookPageReorderedCallback, modifyFontSizeForAllTerms)
+import Termonad.Window (doFind, findAbove, findBelow, showAboutDialog, notebookPageReorderedCallback, modifyFontSizeForAllTerms)
 
 setupScreenStyle :: IO ()
 setupScreenStyle = do

--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -6,7 +6,7 @@ import Termonad.Prelude
 
 import Control.Lens ((^.), (^..), set, view, ix)
 import Data.FileEmbed (embedFile)
-import Data.FocusList (focusList, moveFromToFL, updateFocusFL)
+import Data.FocusList (focusList, updateFocusFL)
 import Data.Sequence (findIndexR)
 import qualified Data.Text as Text
 import Data.Text.Encoding (encodeUtf8)
@@ -120,7 +120,7 @@ import Termonad.Types
   , tmNotebookTabs
   )
 import Termonad.XML (interfaceText, menuText)
-import Termonad.Window (doFind, findAbove, findBelow, showAboutDialog)
+import Termonad.Window (doFind, findAbove, findBelow, showAboutDialog, updateFLTabPos)
 
 setupScreenStyle :: IO ()
 setupScreenStyle = do
@@ -213,29 +213,6 @@ compareScrolledWinAndTab scrollWin flTab =
       ScrolledWindow managedPtrScrollWin = scrollWin
       foreignPtrScrollWin = managedForeignPtr managedPtrScrollWin
   in foreignPtrFLTab == foreignPtrScrollWin
-
-updateFLTabPos :: TMState -> TMWindowId -> Int -> Int -> IO ()
-updateFLTabPos mvarTMState tmWinId oldPos newPos =
-  modifyMVar_ mvarTMState $ \tmState -> do
-    note <- getTMNotebookFromTMState' tmState tmWinId
-    let tabs = tmNotebookTabs note
-        maybeNewTabs = moveFromToFL oldPos newPos tabs
-    case maybeNewTabs of
-      Nothing -> do
-        putStrLn $
-          "in updateFLTabPos, Strange error: couldn't move tabs.\n" <>
-          "old pos: " <> show oldPos <> "\n" <>
-          "new pos: " <> show newPos <> "\n" <>
-          "tabs: " <> show tabs <> "\n" <>
-          "maybeNewTabs: " <> show maybeNewTabs <> "\n" <>
-          "tmState: " <> show tmState
-        pure tmState
-      Just newTabs ->
-        pure $
-          set
-            (lensTMStateWindows . ix tmWinId . lensTMWindowNotebook . lensTMNotebookTabs)
-            newTabs
-            tmState
 
 -- | Try to figure out whether Termonad should exit.  This also used to figure
 -- out if Termonad should close a given terminal.

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -26,7 +26,7 @@ import GI.Gtk
   , notebookGetNthPage
   , notebookGetNPages
   )
-import GI.Pango (FontDescription, fontDescriptionGetSize, fontDescriptionGetSizeIsAbsolute, pattern SCALE, fontDescriptionGetFamily)
+import GI.Pango (FontDescription, fontDescriptionGetSize, fontDescriptionGetSizeIsAbsolute, pattern SCALE, fontDescriptionGetFamily, fontDescriptionNew, fontDescriptionSetFamily, fontDescriptionSetSize, fontDescriptionSetAbsoluteSize)
 import GI.Vte (Terminal, CursorBlinkMode(..))
 import Termonad.Gtk (widgetEq)
 import Termonad.IdMap (IdMap, IdMapKey, singletonIdMap, lookupIdMap)
@@ -342,6 +342,31 @@ fontSizeFromFontDescription fontDesc = do
     else
       let fontRatio :: Double = fromIntegral currSize / fromIntegral SCALE
       in FontSizePoints $ round fontRatio
+
+-- | Create a 'FontDescription' from a 'FontSize' and font family.
+createFontDesc
+  :: FontSize
+  -> Text
+  -- ^ font family
+  -> IO FontDescription
+createFontDesc fontSz fontFam = do
+  fontDesc <- fontDescriptionNew
+  fontDescriptionSetFamily fontDesc fontFam
+  setFontDescSize fontDesc fontSz
+  pure fontDesc
+
+-- | Set the size of a 'FontDescription' from a 'FontSize'.
+setFontDescSize :: FontDescription -> FontSize -> IO ()
+setFontDescSize fontDesc (FontSizePoints points) =
+  fontDescriptionSetSize fontDesc $ fromIntegral (points * fromIntegral SCALE)
+setFontDescSize fontDesc (FontSizeUnits units) =
+  fontDescriptionSetAbsoluteSize fontDesc $ units * fromIntegral SCALE
+
+-- | Create a 'FontDescription' from the 'fontSize' and 'fontFamily' inside a 'TMConfig'.
+createFontDescFromConfig :: TMConfig -> IO FontDescription
+createFontDescFromConfig tmConfig = do
+  let fontConf = fontConfig (options tmConfig)
+  createFontDesc (fontSize fontConf) (fontFamily fontConf)
 
 -- | Settings for the font to be used in Termonad.
 data FontConfig = FontConfig

--- a/src/Termonad/Window.hs
+++ b/src/Termonad/Window.hs
@@ -135,6 +135,13 @@ import Termonad.Types
   )
 import Termonad.XML (interfaceText, menuText)
 
+showAboutDialog :: ApplicationWindow -> IO ()
+showAboutDialog win = do
+  aboutDialog <- aboutDialogNew
+  windowSetTransientFor aboutDialog (Just win)
+  void $ dialogRun aboutDialog
+  widgetDestroy aboutDialog
+
 showFindDialog :: ApplicationWindow -> IO (Maybe Text)
 showFindDialog win = do
   dialog <- dialogNew

--- a/src/Termonad/Window.hs
+++ b/src/Termonad/Window.hs
@@ -1,0 +1,251 @@
+
+module Termonad.Window where
+
+import Termonad.Prelude
+
+import Control.Lens ((^.), (^..), set, view, ix)
+import Data.FileEmbed (embedFile)
+import Data.FocusList (focusList, moveFromToFL, updateFocusFL)
+import Data.Sequence (findIndexR)
+import qualified Data.Text as Text
+import Data.Text.Encoding (encodeUtf8)
+import GI.Gdk (castTo, managedForeignPtr, screenGetDefault)
+import GI.Gio
+  ( ApplicationFlags(ApplicationFlagsFlagsNone)
+  , MenuModel(MenuModel)
+  , actionMapAddAction
+  , applicationQuit
+  , applicationRun
+  , onApplicationActivate
+  , onApplicationStartup
+  , onSimpleActionActivate
+  , simpleActionNew
+  )
+import GI.Gtk
+  ( Application
+  , ApplicationWindow(ApplicationWindow)
+  , Box(Box)
+  , PositionType(PositionTypeRight)
+  , ResponseType(ResponseTypeNo, ResponseTypeYes)
+  , ScrolledWindow(ScrolledWindow)
+  , pattern STYLE_PROVIDER_PRIORITY_APPLICATION
+  , aboutDialogNew
+  , applicationAddWindow
+  , applicationGetActiveWindow
+  , applicationSetAccelsForAction
+  , applicationSetMenubar
+  , applicationWindowSetShowMenubar
+  , boxPackStart
+  , builderNewFromString
+  , builderSetApplication
+  , containerAdd
+  , cssProviderLoadFromData
+  , cssProviderNew
+  , dialogAddButton
+  , dialogGetContentArea
+  , dialogNew
+  , dialogResponse
+  , dialogRun
+  , entryGetText
+  , entryNew
+  , gridAttachNextTo
+  , gridNew
+  , labelNew
+  , notebookGetNPages
+  , notebookNew
+  , notebookSetShowBorder
+  , onEntryActivate
+  , onNotebookPageRemoved
+  , onNotebookPageReordered
+  , onNotebookSwitchPage
+  , onWidgetDeleteEvent
+  , setWidgetMargin
+  , styleContextAddProviderForScreen
+  , widgetDestroy
+  , widgetGrabFocus
+  , widgetSetCanFocus
+  , widgetShow
+  , widgetShowAll
+  , windowPresent
+  , windowSetDefaultIcon
+  , windowSetTitle
+  , windowSetTransientFor
+  )
+import qualified GI.Gtk as Gtk
+import GI.Pango
+  ( FontDescription
+  , pattern SCALE
+  , fontDescriptionNew
+  , fontDescriptionSetFamily
+  , fontDescriptionSetSize
+  , fontDescriptionSetAbsoluteSize
+  )
+import GI.Vte
+  ( catchRegexError
+  , regexNewForSearch
+  , terminalCopyClipboard
+  , terminalPasteClipboard
+  , terminalSearchFindNext
+  , terminalSearchFindPrevious
+  , terminalSearchSetRegex
+  , terminalSearchSetWrapAround
+  , terminalSetFont
+  )
+import Termonad.Gtk (appNew, imgToPixbuf, objFromBuildUnsafe)
+import Termonad.Keys (handleKeyPress)
+import Termonad.Lenses
+  ( lensConfirmExit
+  , lensFontConfig
+  , lensOptions
+  , lensShowMenu
+  , lensTMNotebookTabs
+  , lensTMNotebookTabTerm
+  , lensTMStateApp
+  , lensTMStateConfig
+  , lensTMStateFontDesc
+  , lensTerm
+  , lensTMStateWindows, lensTMWindowNotebook
+  )
+import Termonad.Preferences (showPreferencesDialog)
+import Termonad.Term
+  ( createTerm
+  , relabelTabs
+  , termNextPage
+  , termPrevPage
+  , termExitFocused
+  , setShowTabs
+  )
+import Termonad.Types
+  ( FontConfig(..)
+  , FontSize(FontSizePoints, FontSizeUnits)
+  , TMConfig
+  , TMNotebookTab
+  , TMState
+  , TMState'
+  , TMWindowId
+  , fontSizeFromFontDescription
+  , getFocusedTermFromState
+  , getTMNotebookFromTMState
+  , getTMNotebookFromTMState'
+  , modFontSize
+  , newEmptyTMState
+  , tmNotebookTabTermContainer
+  , tmNotebookTabs
+  , tmStateApp, getTMWindowFromTMState, tmWindowAppWin
+  )
+import Termonad.XML (interfaceText, menuText)
+
+showFindDialog :: ApplicationWindow -> IO (Maybe Text)
+showFindDialog win = do
+  dialog <- dialogNew
+  box <- dialogGetContentArea dialog
+  grid <- gridNew
+
+  searchForLabel <- labelNew (Just "Search for regex:")
+  containerAdd grid searchForLabel
+  widgetShow searchForLabel
+  setWidgetMargin searchForLabel 10
+
+  searchEntry <- entryNew
+  gridAttachNextTo grid searchEntry (Just searchForLabel) PositionTypeRight 1 1
+  widgetShow searchEntry
+  setWidgetMargin searchEntry 10
+  -- setWidgetMarginBottom searchEntry 20
+  void $
+    onEntryActivate searchEntry $
+      dialogResponse dialog (fromIntegral (fromEnum ResponseTypeYes))
+
+  void $
+    dialogAddButton
+      dialog
+      "Close"
+      (fromIntegral (fromEnum ResponseTypeNo))
+  void $
+    dialogAddButton
+      dialog
+      "Find"
+      (fromIntegral (fromEnum ResponseTypeYes))
+
+  containerAdd box grid
+  widgetShow grid
+  windowSetTransientFor dialog (Just win)
+  res <- dialogRun dialog
+
+  searchString <- entryGetText searchEntry
+  let maybeSearchString =
+        case toEnum (fromIntegral res) of
+          ResponseTypeYes -> Just searchString
+          _ -> Nothing
+
+  widgetDestroy dialog
+
+  pure maybeSearchString
+
+doFind :: TMState -> TMWindowId -> IO ()
+doFind mvarTMState tmWinId = do
+  tmWin <- getTMWindowFromTMState mvarTMState tmWinId
+  let win = tmWindowAppWin tmWin
+  maybeSearchString <- showFindDialog win
+  -- putStrLn $ "trying to find: " <> tshow maybeSearchString
+  maybeTerminal <- getFocusedTermFromState mvarTMState tmWinId
+  case (maybeSearchString, maybeTerminal) of
+    (Just searchString, Just terminal) -> do
+      -- TODO: Figure out how to import the correct pcre flags.
+      --
+      -- If you don't pass the pcre2Multiline flag, VTE gives
+      -- the following warning:
+      --
+      -- (termonad-linux-x86_64:18792): Vte-WARNING **:
+      -- 21:56:31.193: (vtegtk.cc:2269):void
+      -- vte_terminal_search_set_regex(VteTerminal*,
+      -- VteRegex*, guint32): runtime check failed:
+      -- (regex == nullptr ||
+      -- _vte_regex_get_compile_flags(regex) & PCRE2_MULTILINE)
+      --
+      -- However, if you do add the pcre2Multiline flag,
+      -- the terminalSearchSetRegex appears to just completely
+      -- not work.
+      let pcreFlags = 0
+      let newRegex =
+            regexNewForSearch
+              searchString
+              (fromIntegral $ Text.length searchString)
+              pcreFlags
+      eitherRegex <-
+        catchRegexError
+          (fmap Right newRegex)
+          (\_ errMsg -> pure (Left errMsg))
+      case eitherRegex of
+        Left errMsg -> do
+          let msg = "error when creating regex: " <> errMsg
+          hPutStrLn stderr msg
+        Right regex -> do
+          terminalSearchSetRegex terminal (Just regex) pcreFlags
+          terminalSearchSetWrapAround terminal True
+          _matchFound <- terminalSearchFindPrevious terminal
+          -- TODO: Setup an actual logging framework to show these
+          -- kinds of log messages.  Also make a similar change in
+          -- findAbove and findBelow.
+          -- putStrLn $ "was match found: " <> tshow matchFound
+          pure ()
+    _ -> pure ()
+
+findAbove :: TMState -> TMWindowId -> IO ()
+findAbove mvarTMState tmWinId = do
+  maybeTerminal <- getFocusedTermFromState mvarTMState tmWinId
+  case maybeTerminal of
+    Nothing -> pure ()
+    Just terminal -> do
+      _matchFound <- terminalSearchFindPrevious terminal
+      -- putStrLn $ "was match found: " <> tshow matchFound
+      pure ()
+
+findBelow :: TMState -> TMWindowId -> IO ()
+findBelow mvarTMState tmWinId = do
+  maybeTerminal <- getFocusedTermFromState mvarTMState tmWinId
+  case maybeTerminal of
+    Nothing -> pure ()
+    Just terminal -> do
+      _matchFound <- terminalSearchFindNext terminal
+      -- putStrLn $ "was match found: " <> tshow matchFound
+      pure ()

--- a/src/Termonad/Window.hs
+++ b/src/Termonad/Window.hs
@@ -135,7 +135,16 @@ import Termonad.Types
   )
 import Termonad.XML (interfaceText, menuText)
 
-notebookPageReorderedCallback :: TMState -> TMWindowId -> Widget -> Word32 -> IO ()
+-- | This is the callback for when a page in a 'Notebook' has been reordered
+-- (normally caused by a drag-and-drop event).
+notebookPageReorderedCallback
+  :: TMState
+  -> TMWindowId
+  -> Widget
+  -- ^ The child widget that is in the Notebook page.
+  -> Word32
+  -- ^ The new index of the Notebook page.
+  -> IO ()
 notebookPageReorderedCallback mvarTMState tmWinId childWidg pageNum = do
   maybeScrollWin <- castTo ScrolledWindow childWidg
   case maybeScrollWin of

--- a/termonad.cabal
+++ b/termonad.cabal
@@ -74,6 +74,7 @@ library
                      , Termonad.Startup
                      , Termonad.Term
                      , Termonad.Types
+                     , Termonad.Window
                      , Termonad.XML
   other-modules:       Paths_termonad
   build-depends:       base >= 4.13 && < 5


### PR DESCRIPTION
This PR does some small refactoring.  A new Termonad.Window module is created to hold functions that operate on a specific Window.  (As opposed to Termonad.App, which now only holds functions that operate on the whole Termonad application.)

This is more preliminary refactoring for https://github.com/cdepillabout/termonad/issues/6