### PR TITLE
Bump nixpkgs-unstable and default compiler in Nix to ghc94

### DIFF
--- a/.nix-helpers/nixos-vm.nix
+++ b/.nix-helpers/nixos-vm.nix
@@ -37,7 +37,7 @@
     jq
     ltrace
     nix-bash-completions
-    pkgconfig
+    pkg-config
     psmisc
     screen
     strace

--- a/.nix-helpers/overlays.nix
+++ b/.nix-helpers/overlays.nix
@@ -78,7 +78,7 @@ let
     #
     # Either this, or termonadKnownWorkingHaskellPkgSet can be changed in an overlay
     # if you want to use a different GHC to build Termonad.
-    termonadCompilerVersion = "ghc92";
+    termonadCompilerVersion = "ghc94";
 
     # A Haskell package set where we know the GHC version works to compile
     # Termonad.  This is basically just a shortcut so that other Nix files

--- a/.nix-helpers/simple-cabal-shell.nix
+++ b/.nix-helpers/simple-cabal-shell.nix
@@ -102,8 +102,8 @@ pkgs.mkShell {
     ghc-real
     cabal-install-real
 
-    # pkgconfig for linking pkgconfig deps
-    pkgs.pkgconfig
+    # pkg-config for linking pkg-config deps
+    pkgs.pkg-config
 
     # Required system libraries
     pkgs.gobject-introspection

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1680213900,
-        "narHash": "sha256-cIDr5WZIj3EkKyCgj/6j3HBH4Jj1W296z7HTcWj1aMA=",
+        "lastModified": 1704194953,
+        "narHash": "sha256-RtDKd8Mynhe5CFnVT8s0/0yqtWFMM9LmCzXv/YKxnq4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e3652e0735fbec227f342712f180f4f21f0594f2",
+        "rev": "bd645e8668ec6612439a9ee7e71f7eac4099d4f6",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This bumps the default compiler in Nix to GHC-9.4, as well as updating the nixpkgs-unstable pin to the latest version.
