### PR TITLE
Add --directory option and default behavior

### DIFF
--- a/src/Termonad/Cli.hs
+++ b/src/Termonad/Cli.hs
@@ -63,6 +63,7 @@ data CliConfigOptions = CliConfigOptions
   , cliConfBoldIsBright :: !(Option Bool)
   , cliConfEnableSixel :: !(Option Bool)
   , cliConfAllowBold :: !(Option Bool)
+  , cliConfDirectory :: !(Option Text)
   } deriving (Eq, Show)
 
 -- | The default 'CliConfigOptions'.  All 'Option's are 'Unset', which means
@@ -102,6 +103,7 @@ defaultCliConfigOptions =
     , cliConfBoldIsBright = Unset
     , cliConfEnableSixel = Unset
     , cliConfAllowBold = Unset
+    , cliConfDirectory = Unset
     }
 
 -- | Extra CLI arguments for values that don't make sense in 'ConfigOptions'.
@@ -180,6 +182,7 @@ cliConfigOptionsParser =
     <*> boldIsBrightParser
     <*> enableSixelParser
     <*> allowBoldParser
+    <*> directoryParser
 
 fontFamilyParser :: Parser (Option Text)
 fontFamilyParser =
@@ -360,6 +363,19 @@ allowBoldParser =
     "Allow Termonad to show bold text.  Defaults to enabled."
     "Disable Termonad from showing text as bold.  Defaults to \
     \allow showing text as bold."
+
+directoryParser :: Parser (Option Text)
+directoryParser =
+  option'
+    (maybeTextReader (\case
+                         x -> Just x
+                         _ -> Nothing))
+    ( short 'c' <>
+      long "directory" <>
+      metavar "DIRECTORY" <>
+      help
+        "Start the terminal in this directory."
+    )
 
 extraCliArgsParser :: Parser ExtraCliArgs
 extraCliArgsParser = pure ExtraCliArgs

--- a/src/Termonad/Startup.hs
+++ b/src/Termonad/Startup.hs
@@ -15,9 +15,11 @@ import Config.Dyre (wrapMain, newParams)
 import Control.Lens (over)
 import System.IO.Error (doesNotExistErrorType, ioeGetErrorType, ioeGetFileName, tryIOError)
 import Termonad.App (start)
-import Termonad.Cli (parseCliArgs, applyCliArgs)
+import Termonad.Cli (parseCliArgs, applyCliArgs, cliConfigOptions, cliConfDirectory)
 import Termonad.Lenses (lensOptions)
-import Termonad.Types (TMConfig)
+import Termonad.Types (TMConfig, Option (Set, Unset))
+import System.Directory (setCurrentDirectory)
+import Data.Text (unpack)
 
 
 -- | Run Termonad with the given 'TMConfig'.
@@ -29,6 +31,9 @@ import Termonad.Types (TMConfig)
 startWithCliArgs :: TMConfig -> IO ()
 startWithCliArgs tmConfig = do
   cliArgs <- parseCliArgs
+  case cliConfDirectory (cliConfigOptions cliArgs) of
+    Set directory -> setCurrentDirectory (unpack directory)
+    Unset         -> mempty
   start (over lensOptions (applyCliArgs cliArgs) tmConfig)
 
 -- | Run Termonad with the given 'TMConfig'.

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -89,6 +89,7 @@ import GI.Gtk
   , widgetSetHexpand
   , widgetShow
   , windowSetFocus
+  , windowSetTitle
   , windowSetTransientFor
   )
 import GI.Pango (EllipsizeMode(EllipsizeModeMiddle), FontDescription)
@@ -510,6 +511,9 @@ createTerm handleKeyPress mvarTMState tmWinId = do
   void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState tmWinId
   void $ onTerminalWindowTitleChanged vteTerm $ do
     relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
+    maybeTitle <- terminalGetWindowTitle vteTerm
+    let title = fromMaybe "shell" maybeTitle
+    windowSetTitle appWin title
   void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState tmWinId
   void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState tmWinId
   void $ onWidgetButtonPressEvent vteTerm $ handleMousePress appWin vteTerm


### PR DESCRIPTION
The `--directory DIRECTORY` option allows user to start the terminal in a specified directory.

Also setting some default behavior, thus closing this issue: https://github.com/cdepillabout/termonad/issues/186
