### PR TITLE
Add --directory option and set default behavior

### DIFF
--- a/src/Termonad/App.hs
+++ b/src/Termonad/App.hs
@@ -74,7 +74,8 @@ import Termonad.Lenses
 import Termonad.Preferences (showPreferencesDialog)
 import Termonad.Term (createTerm, setShowTabs)
 import Termonad.Types
-  ( TMConfig
+  ( Option (Set, Unset)
+  , TMConfig
   , TMState
   , TMState'
   , TMWindowId
@@ -84,6 +85,8 @@ import Termonad.Types
   )
 import Termonad.XML (interfaceText, menuText)
 import Termonad.Window (showAboutDialog, modifyFontSizeForAllTerms, setupWindowCallbacks)
+import Termonad.Cli (parseCliArgs, cliConfigOptions, cliConfDirectory)
+import System.Directory (setCurrentDirectory)
 
 setupScreenStyle :: IO ()
 setupScreenStyle = do
@@ -302,6 +305,10 @@ appStartup _app = pure ()
 -- This function __does not__ parse command line arguments.
 start :: TMConfig -> IO ()
 start tmConfig = do
+  cliArgs <- parseCliArgs
+  case cliConfDirectory (cliConfigOptions cliArgs) of
+    Set directory -> setCurrentDirectory (Text.unpack directory)
+    Unset         -> mempty
   -- app <- appNew (Just "haskell.termonad") [ApplicationFlagsFlagsNone]
   -- Make sure the application is not unique, so we can open multiple copies of it.
   app <- appNew Nothing [ApplicationFlagsFlagsNone]

--- a/src/Termonad/Cli.hs
+++ b/src/Termonad/Cli.hs
@@ -63,6 +63,7 @@ data CliConfigOptions = CliConfigOptions
   , cliConfBoldIsBright :: !(Option Bool)
   , cliConfEnableSixel :: !(Option Bool)
   , cliConfAllowBold :: !(Option Bool)
+  , cliConfDirectory :: !(Option Text)
   } deriving (Eq, Show)
 
 -- | The default 'CliConfigOptions'.  All 'Option's are 'Unset', which means
@@ -83,6 +84,7 @@ data CliConfigOptions = CliConfigOptions
 --           , cliConfBoldIsBright = Unset
 --           , cliConfEnableSixel = Unset
 --           , cliConfAllowBold = Unset
+--           , cliConfDirectory = Unset
 --           }
 --   in defaultCliConfigOptions == defCliConfOpt
 -- :}
@@ -102,6 +104,7 @@ defaultCliConfigOptions =
     , cliConfBoldIsBright = Unset
     , cliConfEnableSixel = Unset
     , cliConfAllowBold = Unset
+    , cliConfDirectory = Unset
     }
 
 -- | Extra CLI arguments for values that don't make sense in 'ConfigOptions'.
@@ -180,6 +183,7 @@ cliConfigOptionsParser =
     <*> boldIsBrightParser
     <*> enableSixelParser
     <*> allowBoldParser
+    <*> directoryParser
 
 fontFamilyParser :: Parser (Option Text)
 fontFamilyParser =
@@ -360,6 +364,19 @@ allowBoldParser =
     "Allow Termonad to show bold text.  Defaults to enabled."
     "Disable Termonad from showing text as bold.  Defaults to \
     \allow showing text as bold."
+
+directoryParser :: Parser (Option Text)
+directoryParser =
+  option'
+    (maybeTextReader (\case
+                         x -> Just x
+                         _ -> Nothing))
+    ( short 'c' <>
+      long "directory" <>
+      metavar "DIRECTORY" <>
+      help
+        "Start the terminal in this directory."
+    )
 
 extraCliArgsParser :: Parser ExtraCliArgs
 extraCliArgsParser = pure ExtraCliArgs

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -89,6 +89,7 @@ import GI.Gtk
   , widgetSetHexpand
   , widgetShow
   , windowSetFocus
+  , windowSetTitle
   , windowSetTransientFor
   )
 import GI.Pango (EllipsizeMode(EllipsizeModeMiddle), FontDescription)
@@ -510,6 +511,9 @@ createTerm handleKeyPress mvarTMState tmWinId = do
   void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState tmWinId
   void $ onTerminalWindowTitleChanged vteTerm $ do
     relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
+    maybeTitle <- terminalGetWindowTitle vteTerm
+    let title = fromMaybe "shell" maybeTitle
+    windowSetTitle appWin title
   void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState tmWinId
   void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState tmWinId
   void $ onWidgetButtonPressEvent vteTerm $ handleMousePress appWin vteTerm


### PR DESCRIPTION
Actually, this gonna break the user config that uses `start` function, like so:

```
Invalid option `--dyre-master-binary=`
```