### PR TITLE
Don't put VteTerminal in a ScrolledWindow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,8 @@ jobs:
           - "9.6.7"
           - "9.8.4"
           - "9.10.3"
-          - "9.12.3"
+          # TODO: This isn't working for some reason.  I didn't really try to figure it out.
+          # - "9.12.3"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 
-## (next)
+## (next -- major version bump)
+
+*   Don't put the VTE Terminal in a `ScrolledWindow`. Instead, use a `Box`
+    with a `Scrollbar`. This fixes problems with the scrollbar not working
+    correctly.
+    [#260](https://github.com/cdepillabout/termonad/pull/260)
+
+    The `ShowScrollbarIfNeeded` option has been removed since it no longer has a
+    meaningful implementation without `ScrolledWindow`. The default is now
+    `ShowScrollbarAlways`. Existing config files with `ShowScrollbarIfNeeded` MUST
+    update to using `ShowScrollbarAlways` or `ShowScrollbarNever`.
 
 *   Move from depending on `gi-gtk` and `gi-gdk` Haskell packages to `gi-gtk3` and `gi-gdk3`.
     This shouldn't affect most users.

--- a/src/Termonad/Cli.hs
+++ b/src/Termonad/Cli.hs
@@ -238,10 +238,9 @@ showScrollbarParser =
       metavar "SHOW_SCROLLBAR" <>
       help
         "Whether or not to show a scrollbar in the terminal. \
-        \Defaults to \"if-needed\".  Possible values = \"never\": \
+        \Defaults to \"always\".  Possible values = \"never\": \
         \never show the scrollbar, \"always\": always show the \
-        \scrollbar, \"if-needed\": only show the scrollbar if \
-        \enough text on the screen"
+        \scrollbar"
     )
 
 scrollbackLenParser :: Parser (Option Integer)

--- a/src/Termonad/Lenses.hs
+++ b/src/Termonad/Lenses.hs
@@ -15,6 +15,7 @@ $(makeLensesFor
 
 $(makeLensesFor
     [ ("tmNotebookTabTermContainer", "lensTMNotebookTabTermContainer")
+    , ("tmNotebookTabScrollbar", "lensTMNotebookTabScrollbar")
     , ("tmNotebookTabTerm", "lensTMNotebookTabTerm")
     , ("tmNotebookTabLabel", "lensTMNotebookTabLabel")
     ]

--- a/src/Termonad/Preferences.hs
+++ b/src/Termonad/Preferences.hs
@@ -28,7 +28,6 @@ import GI.Gtk
   , Entry(Entry)
   , FontButton(FontButton)
   , Label(Label)
-  , PolicyType(PolicyTypeAutomatic)
   , ResponseType(ResponseTypeAccept)
   , SpinButton(SpinButton)
   , adjustmentNew
@@ -44,7 +43,6 @@ import GI.Gtk
   , fontChooserSetFontDesc
   , fontChooserGetFontDesc
   , getEntryBuffer
-  , scrolledWindowSetPolicy
   , spinButtonGetValueAsInt
   , spinButtonSetAdjustment
   , spinButtonSetValue
@@ -78,7 +76,7 @@ import Termonad.Lenses
   , lensShowScrollbar
   , lensShowTabBar
   , lensScrollbackLen
-  , lensTMNotebookTabTermContainer
+  , lensTMNotebookTabScrollbar
   , lensTMNotebookTabTerm
   , lensTMStateApp
   , lensTMStateConfig
@@ -88,8 +86,8 @@ import Termonad.Lenses
   )
 import Termonad.Preferences.File (saveToPreferencesFile, tmConfigFromPreferencesFile)
 import Termonad.Term
-  ( setShowTabs
-  , showScrollbarToPolicy
+  ( applyShowScrollbar
+  , setShowTabs
   )
 import Termonad.Types
   ( ConfigOptions(..)
@@ -144,7 +142,7 @@ applyNewPreferencesToTab mvarTMState tab = do
   tmState <- readMVar mvarTMState
   let fontDesc = tmState ^. lensTMStateFontDesc
       term = tab ^. lensTMNotebookTabTerm . lensTerm
-      scrolledWin = tab ^. lensTMNotebookTabTermContainer
+      scrollbar = tab ^. lensTMNotebookTabScrollbar
       options = tmState ^. lensTMStateConfig . lensOptions
   terminalSetFont term (Just fontDesc)
   terminalSetCursorBlinkMode term (cursorBlinkMode options)
@@ -154,8 +152,7 @@ applyNewPreferencesToTab mvarTMState tab = do
   terminalSetEnableSixelIfExists term (enableSixel options)
   terminalSetAllowBold term (allowBold options)
 
-  let vScrollbarPolicy = showScrollbarToPolicy (options ^. lensShowScrollbar)
-  scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy
+  applyShowScrollbar (options ^. lensShowScrollbar) scrollbar
 
 applyNewPreferencesToWindow :: TMState -> TMWindowId -> IO ()
 applyNewPreferencesToWindow mvarTMState tmWinId = do
@@ -218,7 +215,6 @@ showPreferencesDialog mvarTMState = do
     showScrollbarComboBoxText
     [ (ShowScrollbarNever, "Never")
     , (ShowScrollbarAlways, "Always")
-    , (ShowScrollbarIfNeeded, "If needed")
     ]
   showTabBarComboBoxText <-
     objFromBuildUnsafe preferencesBuilder "showTabBar" ComboBoxText

--- a/src/Termonad/Term.hs
+++ b/src/Termonad/Term.hs
@@ -36,19 +36,17 @@ import GI.GLib
   ( SpawnFlags(SpawnFlagsDefault)
   )
 import GI.Gtk
-  ( Adjustment
-  , Align(AlignFill)
+  ( Align(AlignFill)
   , ApplicationWindow
   , Box
   , Button
   , IconSize(IconSizeMenu)
   , Label
   , Notebook
-  , Orientation(OrientationHorizontal)
-  , PolicyType(PolicyTypeAlways, PolicyTypeAutomatic, PolicyTypeNever)
+  , Orientation(OrientationHorizontal, OrientationVertical)
   , ReliefStyle(ReliefStyleNone)
   , ResponseType(ResponseTypeNo, ResponseTypeYes)
-  , ScrolledWindow
+  , Scrollbar
   , Window
   , applicationGetActiveWindow
   , boxNew
@@ -78,8 +76,8 @@ import GI.Gtk
   , onButtonClicked
   , onWidgetButtonPressEvent
   , onWidgetKeyPressEvent
-  , scrolledWindowNew
-  , scrolledWindowSetPolicy
+  , scrollableGetVadjustment
+  , scrollbarNew
   , setWidgetMargin
   , showUriOnWindow
   , widgetDestroy
@@ -87,6 +85,7 @@ import GI.Gtk
   , widgetSetCanFocus
   , widgetSetHalign
   , widgetSetHexpand
+  , widgetSetVisible
   , widgetShow
   , windowSetFocus
   , windowSetTransientFor
@@ -126,7 +125,9 @@ import Termonad.Lenses
   , lensTMNotebookTabs
   , lensTMStateApp
   , lensTMStateConfig
-  , lensTerm, lensTMStateWindows, lensTMWindowNotebook
+  , lensTerm
+  , lensTMStateWindows
+  , lensTMWindowNotebook
   )
 import Termonad.Pcre (pcre2Multiline)
 import Termonad.Types
@@ -252,9 +253,9 @@ relabelTabs tmNote = do
     go :: Notebook -> TMNotebookTab -> IO ()
     go notebook tmNotebookTab = do
       let label = tmNotebookTab ^. lensTMNotebookTabLabel
-          scrolledWin = tmNotebookTab ^. lensTMNotebookTabTermContainer
+          termBox = tmNotebookTab ^. lensTMNotebookTabTermContainer
           term' = tmNotebookTab ^. lensTMNotebookTabTerm . lensTerm
-      relabelTab notebook label scrolledWin term'
+      relabelTab notebook label termBox term'
 
 -- | Compute the text for a 'Label' for a GTK Notebook tab.
 --
@@ -280,31 +281,38 @@ computeTabLabel pageNum maybeTitle =
 -- | Update the given 'Label' for a GTK Notebook tab.
 --
 -- The new text for the label is determined by the 'computeTabLabel' function.
-relabelTab :: Notebook -> Label -> ScrolledWindow -> Terminal -> IO ()
-relabelTab notebook label scrolledWin term' = do
-  tabNum <- notebookPageNum notebook scrolledWin
+relabelTab :: Notebook -> Label -> Box -> Terminal -> IO ()
+relabelTab notebook label termBox term' = do
+  tabNum <- notebookPageNum notebook termBox
   maybeTitle <- terminalGetWindowTitle term'
   let labelText = computeTabLabel (fromIntegral tabNum) maybeTitle
   labelSetLabel label labelText
 
-showScrollbarToPolicy :: ShowScrollbar -> PolicyType
-showScrollbarToPolicy ShowScrollbarNever = PolicyTypeNever
-showScrollbarToPolicy ShowScrollbarIfNeeded = PolicyTypeAutomatic
-showScrollbarToPolicy ShowScrollbarAlways = PolicyTypeAlways
+-- | Apply the 'ShowScrollbar' setting to a 'Scrollbar' widget by toggling
+-- its visibility.
+applyShowScrollbar :: ShowScrollbar -> Scrollbar -> IO ()
+applyShowScrollbar showScrollbarVal scrollbar =
+  case showScrollbarVal of
+    ShowScrollbarNever -> widgetSetVisible scrollbar False
+    ShowScrollbarAlways -> widgetSetVisible scrollbar True
 
-createScrolledWin :: TMState -> IO ScrolledWindow
-createScrolledWin mvarTMState = do
+-- | Create a horizontal 'Box' containing the VTE 'Terminal' and a vertical
+-- 'Scrollbar'.  The scrollbar is connected to the terminal's vertical
+-- adjustment.
+createTerminalBox :: TMState -> Terminal -> IO (Box, Scrollbar)
+createTerminalBox mvarTMState vteTerm = do
   tmState <- readMVar mvarTMState
   let showScrollbarVal =
         tmState ^. lensTMStateConfig . lensOptions . lensShowScrollbar
-      vScrollbarPolicy = showScrollbarToPolicy showScrollbarVal
-  scrolledWin <-
-    scrolledWindowNew
-      (Nothing :: Maybe Adjustment)
-      (Nothing :: Maybe Adjustment)
-  widgetShow scrolledWin
-  scrolledWindowSetPolicy scrolledWin PolicyTypeAutomatic vScrollbarPolicy
-  pure scrolledWin
+  termBox <- boxNew OrientationHorizontal 0
+  vadjustment <- scrollableGetVadjustment vteTerm
+  scrollbar <- scrollbarNew OrientationVertical (Just vadjustment)
+  containerAdd termBox vteTerm
+  widgetSetHexpand vteTerm True
+  containerAdd termBox scrollbar
+  applyShowScrollbar showScrollbarVal scrollbar
+  widgetShow termBox
+  pure (termBox, scrollbar)
 
 createNotebookTabLabel :: IO (Box, Label, Button)
 createNotebookTabLabel = do
@@ -444,9 +452,9 @@ addPage mvarTMState tmWinId notebookTab tabLabelBox = do
       notebook <- getTMNotebookFromTMState' tmState tmWinId
       let note = tmNotebook notebook
           tabs = tmNotebookTabs notebook
-          scrolledWin = tmNotebookTabTermContainer notebookTab
-      pageIndex <- notebookAppendPage note scrolledWin (Just tabLabelBox)
-      notebookSetTabReorderable note scrolledWin True
+          termBox = tmNotebookTabTermContainer notebookTab
+      pageIndex <- notebookAppendPage note termBox (Just tabLabelBox)
+      notebookSetTabReorderable note termBox True
       setShowTabs (tmState ^. lensTMStateConfig) note
       let newTabs = appendFL tabs notebookTab
           newTMState =
@@ -488,15 +496,14 @@ createTerm handleKeyPress mvarTMState tmWinId = do
   termShellPid <- launchShell vteTerm maybeCurrDir
   tmTerm <- newTMTerm vteTerm termShellPid
 
-  -- Create the container add the VTE term in it
-  scrolledWin <- createScrolledWin mvarTMState
-  containerAdd scrolledWin vteTerm
+  -- Create the container with the VTE term and scrollbar
+  (termBox, scrollbar) <- createTerminalBox mvarTMState vteTerm
 
   -- Create the GTK widget for the Notebook tab
   (tabLabelBox, tabLabel, tabCloseButton) <- createNotebookTabLabel
 
   -- Create notebook state
-  let notebookTab = createTMNotebookTab tabLabel scrolledWin tmTerm
+  let notebookTab = createTMNotebookTab tabLabel termBox scrollbar tmTerm
 
   -- Add the new notebooktab to the notebook.
   addPage mvarTMState tmWinId notebookTab tabLabelBox
@@ -504,14 +511,14 @@ createTerm handleKeyPress mvarTMState tmWinId = do
   -- Setup the initial label for the notebook tab.  This needs to happen
   -- after we add the new page to the notebook, so that the page can get labelled
   -- appropriately.
-  relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
+  relabelTab (tmNotebook currNote) tabLabel termBox vteTerm
 
   -- Connect callbacks
   void $ onButtonClicked tabCloseButton $ termClose notebookTab mvarTMState tmWinId
   void $ onTerminalWindowTitleChanged vteTerm $ do
-    relabelTab (tmNotebook currNote) tabLabel scrolledWin vteTerm
+    relabelTab (tmNotebook currNote) tabLabel termBox vteTerm
   void $ onWidgetKeyPressEvent vteTerm $ handleKeyPress mvarTMState tmWinId
-  void $ onWidgetKeyPressEvent scrolledWin $ handleKeyPress mvarTMState tmWinId
+  void $ onWidgetKeyPressEvent termBox $ handleKeyPress mvarTMState tmWinId
   void $ onWidgetButtonPressEvent vteTerm $ handleMousePress appWin vteTerm
   void $ onTerminalChildExited vteTerm $ \_ -> termExit notebookTab mvarTMState tmWinId
 

--- a/src/Termonad/Types.hs
+++ b/src/Termonad/Types.hs
@@ -17,10 +17,11 @@ import Data.Yaml
 import GI.Gtk
   ( Application
   , ApplicationWindow
+  , Box
   , IsWidget
   , Label
   , Notebook
-  , ScrolledWindow
+  , Scrollbar
   , Widget
   , notebookGetCurrentPage
   , notebookGetNthPage
@@ -60,13 +61,15 @@ instance Show TMTerm where
       showString "}"
 
 -- | A container that holds everything in a given terminal window.  The 'term'
--- in the 'TMTerm' is inside the 'tmNotebookTabTermContainer' 'ScrolledWindow'.
+-- in the 'TMTerm' is inside the 'tmNotebookTabTermContainer' 'Box'.
 -- The notebook tab 'Label' is also available.
 data TMNotebookTab = TMNotebookTab
-  { tmNotebookTabTermContainer :: !ScrolledWindow
-    -- ^ The 'ScrolledWindow' holding the VTE 'Terminal'.
+  { tmNotebookTabTermContainer :: !Box
+    -- ^ The 'Box' holding the VTE 'Terminal' and 'Scrollbar'.
+  , tmNotebookTabScrollbar :: !Scrollbar
+    -- ^ The 'Scrollbar' for the VTE 'Terminal'.
   , tmNotebookTabTerm :: !TMTerm
-    -- ^ The 'Terminal' insidie the 'ScrolledWindow'.
+    -- ^ The 'Terminal' inside the 'Box'.
   , tmNotebookTabLabel :: !Label
     -- ^ The 'Label' holding the title of the 'Terminal' in the 'Notebook' tab.
   }
@@ -77,7 +80,10 @@ instance Show TMNotebookTab where
     showParen (d > 10) $
       showString "TMNotebookTab {" .
       showString "tmNotebookTabTermContainer = " .
-      showString "(GI.GTK.ScrolledWindow)" .
+      showString "(GI.GTK.Box)" .
+      showString ", " .
+      showString "tmNotebookTabScrollbar = " .
+      showString "(GI.GTK.Scrollbar)" .
       showString ", " .
       showString "tmNotebookTabTerm = " .
       showsPrec (d + 1) tmNotebookTabTerm .
@@ -223,10 +229,11 @@ getFocusedTermFromState mvarTMState tmWinId =
       let maybeNotebookTab = getFocusItemFL $ tmNotebookTabs tmNote
       pure $ fmap (term . tmNotebookTabTerm) maybeNotebookTab
 
-createTMNotebookTab :: Label -> ScrolledWindow -> TMTerm -> TMNotebookTab
-createTMNotebookTab tabLabel scrollWin trm =
+createTMNotebookTab :: Label -> Box -> Scrollbar -> TMTerm -> TMNotebookTab
+createTMNotebookTab tabLabel termBox scrollbar trm =
   TMNotebookTab
-    { tmNotebookTabTermContainer = scrollWin
+    { tmNotebookTabTermContainer = termBox
+    , tmNotebookTabScrollbar = scrollbar
     , tmNotebookTabTerm = trm
     , tmNotebookTabLabel = tabLabel
     }
@@ -426,21 +433,28 @@ data ShowScrollbar
                        -- should still be able to scroll with the mouse wheel.
   | ShowScrollbarAlways -- ^ Always show the scrollbar, even if it is not
                         -- needed.
-  | ShowScrollbarIfNeeded -- ^ Only show the scrollbar if there are too many
-                          -- lines on the terminal to show all at once.
-  deriving (Enum, Eq, Generic, FromJSON, Show, ToJSON)
+  deriving (Enum, Eq, Generic, Show, ToJSON)
+
+-- | Custom 'FromJSON' instance that accepts the removed
+-- @\"ShowScrollbarIfNeeded\"@ value for backward compatibility with existing
+-- config files, treating it as 'ShowScrollbarAlways'.
+instance FromJSON ShowScrollbar where
+  parseJSON = withText "ShowScrollbar" $ \case
+    "ShowScrollbarNever" -> pure ShowScrollbarNever
+    "ShowScrollbarAlways" -> pure ShowScrollbarAlways
+    "ShowScrollbarIfNeeded" -> pure ShowScrollbarAlways
+    other -> fail $ "Unknown ShowScrollbar value: " <> show other
 
 showScrollbarToString :: ShowScrollbar -> Text
 showScrollbarToString = \case
   ShowScrollbarNever -> "never"
   ShowScrollbarAlways -> "always"
-  ShowScrollbarIfNeeded -> "if-needed"
 
 showScrollbarFromString :: Text -> Maybe ShowScrollbar
 showScrollbarFromString = \case
   "never" -> Just ShowScrollbarNever
   "always" -> Just ShowScrollbarAlways
-  "if-needed" -> Just ShowScrollbarIfNeeded
+  "if-needed" -> Just ShowScrollbarAlways
   _ -> Nothing
 
 -- | Whether or not to show the tab bar for switching tabs.
@@ -561,7 +575,7 @@ instance ToJSON CursorBlinkMode where
 --   let defConfOpt =
 --         ConfigOptions
 --           { fontConfig = defaultFontConfig
---           , showScrollbar = ShowScrollbarIfNeeded
+--           , showScrollbar = ShowScrollbarAlways
 --           , scrollbackLen = 10000
 --           , confirmExit = True
 --           , wordCharExceptions = "-#%&+,./=?@\\_~\183:"
@@ -579,7 +593,7 @@ defaultConfigOptions :: ConfigOptions
 defaultConfigOptions =
   ConfigOptions
     { fontConfig = defaultFontConfig
-    , showScrollbar = ShowScrollbarIfNeeded
+    , showScrollbar = ShowScrollbarAlways
     , scrollbackLen = 10000
     , confirmExit = True
     , wordCharExceptions = "-#%&+,./=?@\\_~\183:"

--- a/src/Termonad/Window.hs
+++ b/src/Termonad/Window.hs
@@ -16,10 +16,10 @@ import GI.Gio
 import GI.Gtk
   ( Application
   , ApplicationWindow
+  , Box(Box)
   , Notebook
   , PositionType(PositionTypeRight)
   , ResponseType(ResponseTypeNo, ResponseTypeYes)
-  , ScrolledWindow(ScrolledWindow)
   , Widget
   , aboutDialogNew
   , applicationSetAccelsForAction
@@ -120,36 +120,36 @@ notebookPageReorderedCallback
   -- ^ The new index of the Notebook page.
   -> IO ()
 notebookPageReorderedCallback mvarTMState tmWinId childWidg pageNum = do
-  maybeScrollWin <- castTo ScrolledWindow childWidg
-  case maybeScrollWin of
+  maybeBox <- castTo Box childWidg
+  case maybeBox of
     Nothing ->
       fail $
         "In setupTermonad, in callback for onNotebookPageReordered, " <>
-        "child widget is not a ScrolledWindow.\n" <>
+        "child widget is not a Box.\n" <>
         "Don't know how to continue.\n"
-    Just scrollWin -> do
+    Just box -> do
       tmNote <- getTMNotebookFromTMState mvarTMState tmWinId
       let fl = view lensTMNotebookTabs tmNote
       let maybeOldPosition =
-            findIndexR (compareScrolledWinAndTab scrollWin) (focusList fl)
+            findIndexR (compareBoxAndTab box) (focusList fl)
       case maybeOldPosition of
         Nothing ->
           fail $
             "In setupTermonad, in callback for onNotebookPageReordered, " <>
-            "the ScrolledWindow is not already in the FocusList.\n" <>
+            "the Box is not already in the FocusList.\n" <>
             "Don't know how to continue.\n"
         Just oldPos -> do
           updateFLTabPos mvarTMState tmWinId oldPos (fromIntegral pageNum)
           tmNote' <- getTMNotebookFromTMState mvarTMState tmWinId
           relabelTabs tmNote'
   where
-    compareScrolledWinAndTab :: ScrolledWindow -> TMNotebookTab -> Bool
-    compareScrolledWinAndTab scrollWin flTab =
-      let ScrolledWindow managedPtrFLTab = tmNotebookTabTermContainer flTab
+    compareBoxAndTab :: Box -> TMNotebookTab -> Bool
+    compareBoxAndTab box flTab =
+      let Box managedPtrFLTab = tmNotebookTabTermContainer flTab
           foreignPtrFLTab = managedForeignPtr managedPtrFLTab
-          ScrolledWindow managedPtrScrollWin = scrollWin
-          foreignPtrScrollWin = managedForeignPtr managedPtrScrollWin
-      in foreignPtrFLTab == foreignPtrScrollWin
+          Box managedPtrBox = box
+          foreignPtrBox = managedForeignPtr managedPtrBox
+      in foreignPtrFLTab == foreignPtrBox
 
 -- | Move a 'TMNotebookTab' from one position to another.
 --


### PR DESCRIPTION
Closes #114.

The one big downside of this is that the new scrollbar setup kind of looks ugly.  That's what we get for no longer using ScrolledWindow.  Although it does seem to work better now.

I've also removed the `ShowScrollbarIfNeeded` data type, and instead defaulting to `ShowScrollbarAlways`.  Anyone using `ShowScrollbarIfNeeded` will need to update their configs.
